### PR TITLE
FIX COMBOBOX OVERFLOW

### DIFF
--- a/lib/rbui/combobox/combobox_list.rb
+++ b/lib/rbui/combobox/combobox_list.rb
@@ -22,7 +22,7 @@ module RBUI
           rbui__combobox_target: "list"
         },
         role: "listbox",
-        tabindex: "-1",
+        tabindex: "-1"
       }
     end
   end


### PR DESCRIPTION
`RBUI::ComboboxList` does not need to repeat the class defined in `RBUI::ComboboxContent`

BEFORE
![COMBOBOX-BEFORE](https://github.com/user-attachments/assets/2ad8db4d-300d-4375-a40c-8cf374e459e0)

AFTER
![COMBOBOX-AFTER](https://github.com/user-attachments/assets/c60f83df-0503-4a4f-9e76-ad5d986cbf31)