### PR TITLE
Remove tailwind_merge from generator

### DIFF
--- a/lib/generators/rbui/install/install_generator.rb
+++ b/lib/generators/rbui/install/install_generator.rb
@@ -24,9 +24,6 @@ module RBUI
             run "bundle add phlex-rails"
           end
 
-          say "Adding tailwind_merge"
-          run "bundle add tailwind_merge"
-
           say "run phlex install"
           run "bin/rails generate phlex:install"
         end


### PR DESCRIPTION
Removing `bundle add tailwind_merge` from install command since tailwind_merge is already a dependency from rbui.