### PR TITLE
Remove Template Tags and Resolve Stimulus Connection Issues

### DIFF
--- a/lib/rbui/alert_dialog/alert_dialog_content.rb
+++ b/lib/rbui/alert_dialog/alert_dialog_content.rb
@@ -3,7 +3,7 @@
 module RBUI
   class AlertDialogContent < Base
     def view_template(&block)
-      template_tag(**attrs) do
+      div(**attrs) do
         div(data: {controller: "rbui--alert-dialog"}) do
           background
           container(&block)

--- a/lib/rbui/calendar/calendar_days.rb
+++ b/lib/rbui/calendar/calendar_days.rb
@@ -87,7 +87,7 @@ module RBUI
     end
 
     def date_template(target, &block)
-      template_tag(data: {rbui__calendar_target: target}) do
+      div(data: {rbui__calendar_target: target}) do
         td(
           class:
                 "relative p-0 text-center text-sm focus-within:relative focus-within:z-20 [&:has([aria-selected])]:bg-accent [&:has([aria-selected])]:rounded-md",

--- a/lib/rbui/calendar/calendar_weekdays.rb
+++ b/lib/rbui/calendar/calendar_weekdays.rb
@@ -5,7 +5,7 @@ module RBUI
     DAYS = %w[Monday Tuesday Wednesday Thursday Friday Saturday Sunday].freeze
 
     def view_template
-      template_tag(data: {rbui__calendar_target: "weekdaysTemplate"}) do
+      div(data: {rbui__calendar_target: "weekdaysTemplate"}) do
         thead(**attrs) do
           tr(class: "flex") do
             DAYS.each do |day|

--- a/lib/rbui/command/command_dialog_content.rb
+++ b/lib/rbui/command/command_dialog_content.rb
@@ -17,7 +17,7 @@ module RBUI
     end
 
     def view_template(&block)
-      template_tag(data: {rbui__command_target: "content"}) do
+      div(data: {rbui__command_target: "content"}) do
         div(data: {controller: "rbui--command"}) do
           backdrop
           div(**attrs, &block)

--- a/lib/rbui/context_menu/context_menu_content.rb
+++ b/lib/rbui/context_menu/context_menu_content.rb
@@ -3,7 +3,7 @@
 module RBUI
   class ContextMenuContent < Base
     def view_template(&block)
-      template_tag(data: {rbui__context_menu_target: "content"}) do
+      div(data: {rbui__context_menu_target: "content"}) do
         div(**attrs, &block)
       end
     end

--- a/lib/rbui/dialog/dialog_content.rb
+++ b/lib/rbui/dialog/dialog_content.rb
@@ -17,7 +17,7 @@ module RBUI
     end
 
     def view_template
-      template_tag(data: {rbui__dialog_target: "content"}) do
+      div(data: {rbui__dialog_target: "content"}) do
         div(data_controller: "rbui--dialog") do
           backdrop
           div(**attrs) do

--- a/lib/rbui/hover_card/hover_card_content.rb
+++ b/lib/rbui/hover_card/hover_card_content.rb
@@ -3,7 +3,7 @@
 module RBUI
   class HoverCardContent < Base
     def view_template(&block)
-      template_tag(data: {rbui__hover_card_target: "content"}) do
+      div(data: {rbui__hover_card_target: "content"}) do
         div(**attrs, &block)
       end
     end

--- a/lib/rbui/sheet/sheet_content.rb
+++ b/lib/rbui/sheet/sheet_content.rb
@@ -16,7 +16,7 @@ module RBUI
     end
 
     def view_template(&block)
-      template_tag(data: {rbui__sheet_target: "content"}) do
+      div(data: {rbui__sheet_target: "content"}) do
         div(data: {controller: "rbui--sheet-content"}) do
           backdrop
           div(**attrs) do


### PR DESCRIPTION
Template tags are causing issues when connecting Stimulus to the template tag. To resolve this, the template tags were removed and replaced with div elements. This change ensures that Stimulus controllers can connect and function correctly as expected.