### PR TITLE
Revert "alert dialog without template tag"

### DIFF
--- a/lib/rbui/alert_dialog/alert_dialog_content.rb
+++ b/lib/rbui/alert_dialog/alert_dialog_content.rb
@@ -3,7 +3,7 @@
 module RBUI
   class AlertDialogContent < Base
     def view_template(&block)
-      div(class: "hidden") do
+      all_template_tag(**attrs) do
         div(data: {controller: "rbui--alert-dialog"}) do
           background
           container(&block)


### PR DESCRIPTION
Reverts ruby-ui/ruby_ui#178

@SethHorsley , this PR broke the AlertDialog here. May I revert it?