### PR TITLE
Fix stimulus controllers

### DIFF
--- a/lib/generators/ruby_ui/component_generator.rb
+++ b/lib/generators/ruby_ui/component_generator.rb
@@ -74,8 +74,8 @@ module RubyUI
         # Build the new import path
         new_import_path = new_import_path("./#{relative_path.dirname}/#{file_name}")
 
-        # Create the registration name by dasherizing the component name and prefixing with 'ruby_ui--'
-        registration_name = "ruby_ui--#{component_name.dasherize}"
+        # Create the registration name by dasherizing the component name and prefixing with 'ruby-ui--'
+        registration_name = "ruby-ui--#{component_name.dasherize}"
 
         # Return a hash with import, registration, and export statements
         {

--- a/lib/generators/ruby_ui/install/templates/index.js.tt
+++ b/lib/generators/ruby_ui/install/templates/index.js.tt
@@ -4,7 +4,7 @@ import { application } from "../../../app/javascript/controllers/application";
 // import ComboboxController from "./combobox/combobox_controller";
 
 // Register all controllers
-// application.register("ruby_ui--combobox", ComboboxController);
+// application.register("ruby-ui--combobox", ComboboxController);
 
 import RubyUI from "ruby_ui-js";
 RubyUI.initialize(application);

--- a/lib/ruby_ui/accordion/accordion_controller.js
+++ b/lib/ruby_ui/accordion/accordion_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "@hotwired/stimulus";
 import { animate } from "motion";
 
-// Connects to data-controller="ruby_ui--accordion"
+// Connects to data-controller="ruby-ui--accordion"
 export default class extends Controller {
   static targets = ["icon", "content"];
   static values = {

--- a/lib/ruby_ui/accordion/accordion_default_trigger.rb
+++ b/lib/ruby_ui/accordion/accordion_default_trigger.rb
@@ -11,7 +11,7 @@ module RubyUI
 
     def default_attrs
       {
-        data: {action: "click->ruby_ui--accordion#toggle"},
+        data: {action: "click->ruby-ui--accordion#toggle"},
         class: "w-full flex flex-1 items-center justify-between py-4 text-sm font-medium transition-all hover:underline"
       }
     end

--- a/lib/ruby_ui/accordion/accordion_item.rb
+++ b/lib/ruby_ui/accordion/accordion_item.rb
@@ -17,7 +17,7 @@ module RubyUI
     def default_attrs
       {
         data: {
-          controller: "ruby_ui--accordion",
+          controller: "ruby-ui--accordion",
           ruby_ui__accordion_open_value: @open,
           ruby_ui__accordion_rotate_icon_value: @rotate_icon
         },

--- a/lib/ruby_ui/accordion/accordion_trigger.rb
+++ b/lib/ruby_ui/accordion/accordion_trigger.rb
@@ -9,7 +9,7 @@ module RubyUI
     def default_attrs
       {
         type: "button",
-        data: {action: "click->ruby_ui--accordion#toggle"},
+        data: {action: "click->ruby-ui--accordion#toggle"},
         class: "w-full flex flex-1 items-center justify-between py-4 text-sm font-medium transition-all hover:underline"
       }
     end

--- a/lib/ruby_ui/alert_dialog/alert_dialog.rb
+++ b/lib/ruby_ui/alert_dialog/alert_dialog.rb
@@ -16,7 +16,7 @@ module RubyUI
     def default_attrs
       {
         data: {
-          controller: "ruby_ui--alert-dialog",
+          controller: "ruby-ui--alert-dialog",
           ruby_ui__alert_dialog_open_value: @open.to_s
         },
         class: "inline-block"

--- a/lib/ruby_ui/alert_dialog/alert_dialog_cancel.rb
+++ b/lib/ruby_ui/alert_dialog/alert_dialog_cancel.rb
@@ -12,7 +12,7 @@ module RubyUI
       {
         variant: :outline,
         data: {
-          action: "click->ruby_ui--alert-dialog#dismiss"
+          action: "click->ruby-ui--alert-dialog#dismiss"
         },
         class: "mt-2 sm:mt-0"
       }

--- a/lib/ruby_ui/alert_dialog/alert_dialog_controller.js
+++ b/lib/ruby_ui/alert_dialog/alert_dialog_controller.js
@@ -1,6 +1,6 @@
 import { Controller } from "@hotwired/stimulus";
 
-// Connects to data-controller="ruby_ui--alert-dialog"
+// Connects to data-controller="ruby-ui--alert-dialog"
 export default class extends Controller {
   static targets = ["content"];
   static values = {

--- a/lib/ruby_ui/alert_dialog/alert_dialog_trigger.rb
+++ b/lib/ruby_ui/alert_dialog/alert_dialog_trigger.rb
@@ -10,7 +10,7 @@ module RubyUI
 
     def default_attrs
       {
-        data: {action: "click->ruby_ui--alert-dialog#open"},
+        data: {action: "click->ruby-ui--alert-dialog#open"},
         class: "inline-block"
       }
     end

--- a/lib/ruby_ui/calendar/calendar.rb
+++ b/lib/ruby_ui/calendar/calendar.rb
@@ -28,7 +28,7 @@ module RubyUI
       {
         class: "p-3 space-y-4",
         data: {
-          controller: "ruby_ui--calendar",
+          controller: "ruby-ui--calendar",
           ruby_ui__calendar_selected_date_value: @selected_date&.to_s,
           ruby_ui__calendar_format_value: @date_format,
           ruby_ui__calendar_ruby_ui__calendar_input_outlet: @input_id

--- a/lib/ruby_ui/calendar/calendar_controller.js
+++ b/lib/ruby_ui/calendar/calendar_controller.js
@@ -25,7 +25,7 @@ export default class extends Controller {
       default: "yyyy-MM-dd", // Default format
     },
   };
-  static outlets = ["ruby_ui--calendar-input"];
+  static outlets = ["ruby-ui--calendar-input"];
 
   initialize() {
     this.updateCalendar(); // Initial calendar render
@@ -247,4 +247,3 @@ export default class extends Controller {
     }
   }
 }
-

--- a/lib/ruby_ui/calendar/calendar_days.rb
+++ b/lib/ruby_ui/calendar/calendar_days.rb
@@ -17,7 +17,7 @@ module RubyUI
       date_template("selectedDateTemplate") do
         button(
           data_day: "{{day}}",
-          data_action: "click->ruby_ui--calendar#selectDay",
+          data_action: "click->ruby-ui--calendar#selectDay",
           name: "day",
           class:
                 [
@@ -36,7 +36,7 @@ module RubyUI
       date_template("todayDateTemplate") do
         button(
           data_day: "{{day}}",
-          data_action: "click->ruby_ui--calendar#selectDay",
+          data_action: "click->ruby-ui--calendar#selectDay",
           name: "day",
           class:
                 [
@@ -54,7 +54,7 @@ module RubyUI
       date_template("currentMonthDateTemplate") do
         button(
           data_day: "{{day}}",
-          data_action: "click->ruby_ui--calendar#selectDay",
+          data_action: "click->ruby-ui--calendar#selectDay",
           name: "day",
           class:
                 [
@@ -72,7 +72,7 @@ module RubyUI
       date_template("otherMonthDateTemplate") do
         button(
           data_day: "{{day}}",
-          data_action: " click->ruby_ui--calendar#selectDay",
+          data_action: " click->ruby-ui--calendar#selectDay",
           name: "day",
           class:
                 [

--- a/lib/ruby_ui/calendar/calendar_next.rb
+++ b/lib/ruby_ui/calendar/calendar_next.rb
@@ -36,7 +36,7 @@ module RubyUI
         class:
               "inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-input hover:bg-accent hover:text-accent-foreground h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100 absolute right-1",
         type: "button",
-        data_action: "click->ruby_ui--calendar#nextMonth"
+        data_action: "click->ruby-ui--calendar#nextMonth"
       }
     end
   end

--- a/lib/ruby_ui/calendar/calendar_prev.rb
+++ b/lib/ruby_ui/calendar/calendar_prev.rb
@@ -36,7 +36,7 @@ module RubyUI
         class:
               "rdp-button_reset rdp-button inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-input hover:bg-accent hover:text-accent-foreground h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100 absolute left-1",
         type: "button",
-        data_action: "click->ruby_ui--calendar#prevMonth"
+        data_action: "click->ruby-ui--calendar#prevMonth"
       }
     end
   end

--- a/lib/ruby_ui/chart/chart.rb
+++ b/lib/ruby_ui/chart/chart.rb
@@ -15,7 +15,7 @@ module RubyUI
 
     def default_attrs
       {
-        data_controller: "ruby_ui--chart",
+        data_controller: "ruby-ui--chart",
         data_ruby_ui__chart_options_value: @options
       }
     end

--- a/lib/ruby_ui/checkbox/checkbox.rb
+++ b/lib/ruby_ui/checkbox/checkbox.rb
@@ -14,7 +14,7 @@ module RubyUI
         data: {
           ruby_ui__form_field_target: "input",
           ruby_ui__checkbox_group_target: "checkbox",
-          action: "change->ruby_ui--checkbox-group#onChange change->ruby_ui--form-field#onInput invalid->ruby_ui--form-field#onInvalid"
+          action: "change->ruby-ui--checkbox-group#onChange change->ruby-ui--form-field#onInput invalid->ruby-ui--form-field#onInvalid"
         },
         class: "peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 accent-primary"
       }

--- a/lib/ruby_ui/checkbox/checkbox_group.rb
+++ b/lib/ruby_ui/checkbox/checkbox_group.rb
@@ -12,7 +12,7 @@ module RubyUI
       {
         role: "group",
         data: {
-          controller: "ruby_ui--checkbox-group"
+          controller: "ruby-ui--checkbox-group"
         }
       }
     end

--- a/lib/ruby_ui/clipboard/clipboard.rb
+++ b/lib/ruby_ui/clipboard/clipboard.rb
@@ -30,8 +30,8 @@ module RubyUI
     def default_attrs
       {
         data: {
-          controller: "ruby_ui--clipboard",
-          action: "click@window->ruby_ui--clipboard#onClickOutside",
+          controller: "ruby-ui--clipboard",
+          action: "click@window->ruby-ui--clipboard#onClickOutside",
           ruby_ui__clipboard_success_value: @success,
           ruby_ui__clipboard_error_value: @error,
           ruby_ui__clipboard_options_value: @options.to_json

--- a/lib/ruby_ui/clipboard/clipboard_trigger.rb
+++ b/lib/ruby_ui/clipboard/clipboard_trigger.rb
@@ -12,7 +12,7 @@ module RubyUI
       {
         data: {
           ruby_ui__clipboard_target: "trigger",
-          action: "click->ruby_ui--clipboard#copy"
+          action: "click->ruby-ui--clipboard#copy"
         }
       }
     end

--- a/lib/ruby_ui/collapsible/collapsible.rb
+++ b/lib/ruby_ui/collapsible/collapsible.rb
@@ -16,7 +16,7 @@ module RubyUI
     def default_attrs
       {
         data: {
-          controller: "ruby_ui--collapsible",
+          controller: "ruby-ui--collapsible",
           ruby_ui__collapsible_open_value: @open
         }
       }

--- a/lib/ruby_ui/collapsible/collapsible_trigger.rb
+++ b/lib/ruby_ui/collapsible/collapsible_trigger.rb
@@ -11,7 +11,7 @@ module RubyUI
     def default_attrs
       {
         data: {
-          action: "click->ruby_ui--collapsible#toggle"
+          action: "click->ruby-ui--collapsible#toggle"
         }
       }
     end

--- a/lib/ruby_ui/combobox/combobox.rb
+++ b/lib/ruby_ui/combobox/combobox.rb
@@ -11,9 +11,9 @@ module RubyUI
     def default_attrs
       {
         data: {
-          controller: "ruby_ui--combobox",
+          controller: "ruby-ui--combobox",
           ruby_ui__combobox_open_value: "false",
-          action: "click@window->ruby_ui--combobox#onClickOutside",
+          action: "click@window->ruby-ui--combobox#onClickOutside",
           ruby_ui__combobox_ruby_ui__combobox_content_outlet: ".combobox-content",
           ruby_ui__combobox_ruby_ui__combobox_item_outlet: ".combobox-item"
         },

--- a/lib/ruby_ui/combobox/combobox_content.rb
+++ b/lib/ruby_ui/combobox/combobox_content.rb
@@ -9,7 +9,7 @@ module RubyUI
 
     def view_template(&)
       div(**attrs) do
-        div(class: "min-w-max max-h-[300px] overflow-y-auto overflow-x-hidden rounded-md border bg-popover text-popover-foreground shadow-md outline-none animate-out group-data-[ruby_ui--combobox-open-value=true]/combobox:animate-in fade-out-0 group-data-[ruby_ui--combobox-open-value=true]/combobox:fade-in-0 zoom-out-95 group-data-[ruby_ui--combobox-open-value=true]/combobox:zoom-in-95 slide-in-from-top-2", &)
+        div(class: "min-w-max max-h-[300px] overflow-y-auto overflow-x-hidden rounded-md border bg-popover text-popover-foreground shadow-md outline-none animate-out group-data-[ruby-ui--combobox-open-value=true]/combobox:animate-in fade-out-0 group-data-[ruby-ui--combobox-open-value=true]/combobox:fade-in-0 zoom-out-95 group-data-[ruby-ui--combobox-open-value=true]/combobox:zoom-in-95 slide-in-from-top-2", &)
       end
     end
 
@@ -20,9 +20,9 @@ module RubyUI
         id: @id,
         role: "listbox",
         data: {
-          controller: "ruby_ui--combobox-content",
+          controller: "ruby-ui--combobox-content",
           ruby_ui__combobox_target: "content",
-          action: "keydown.enter->ruby_ui--combobox#onKeyEnter keydown.esc->ruby_ui--combobox#onEscKey keydown.down->ruby_ui--combobox#onKeyDown keydown.up->ruby_ui--combobox#onKeyUp"
+          action: "keydown.enter->ruby-ui--combobox#onKeyEnter keydown.esc->ruby-ui--combobox#onEscKey keydown.down->ruby-ui--combobox#onKeyDown keydown.up->ruby-ui--combobox#onKeyUp"
         },
         class: "combobox-content hidden w-full absolute top-0 left-0 z-50"
       }

--- a/lib/ruby_ui/combobox/combobox_content_controller.js
+++ b/lib/ruby_ui/combobox/combobox_content_controller.js
@@ -20,7 +20,7 @@ export default class extends Controller {
     this.groupTargets.forEach((group) => {
       const hasVisibleItems =
         group.querySelectorAll(
-          "[data-ruby_ui--combobox-content-target='item']:not(.hidden)",
+          "[data-ruby-ui--combobox-content-target='item']:not(.hidden)",
         ).length > 0;
       this.#toggleVisibility([group], hasVisibleItems);
     });

--- a/lib/ruby_ui/combobox/combobox_controller.js
+++ b/lib/ruby_ui/combobox/combobox_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "@hotwired/stimulus";
 import { computePosition, autoUpdate, offset } from "@floating-ui/dom";
 
-export const POPOVER_OPENED = "ruby_ui--combobox#popoverOpened";
+export const POPOVER_OPENED = "ruby-ui--combobox#popoverOpened";
 
 export default class extends Controller {
   static targets = [
@@ -14,7 +14,7 @@ export default class extends Controller {
     "item",
   ];
   static values = { open: Boolean };
-  static outlets = ["ruby_ui--combobox-item", "ruby_ui--combobox-content"];
+  static outlets = ["ruby-ui--combobox-item", "ruby-ui--combobox-content"];
 
   constructor(...args) {
     super(...args);

--- a/lib/ruby_ui/combobox/combobox_input.rb
+++ b/lib/ruby_ui/combobox/combobox_input.rb
@@ -14,7 +14,7 @@ module RubyUI
         data: {
           ruby_ui__combobox_target: "input",
           ruby_ui__form_field_target: "input",
-          action: "change->ruby_ui--form-field#onChange invalid->ruby_ui--form-field#onInvalid"
+          action: "change->ruby-ui--form-field#onChange invalid->ruby-ui--form-field#onInvalid"
         }
       }
     end

--- a/lib/ruby_ui/combobox/combobox_item.rb
+++ b/lib/ruby_ui/combobox/combobox_item.rb
@@ -43,8 +43,8 @@ module RubyUI
           value: @value,
           ruby_ui__combobox_target: "item",
           ruby_ui__combobox_content_target: "item",
-          controller: "ruby_ui--combobox-item",
-          action: "click->ruby_ui--combobox#onItemSelected"
+          controller: "ruby-ui--combobox-item",
+          action: "click->ruby-ui--combobox#onItemSelected"
         },
         aria_selected: "false"
       }

--- a/lib/ruby_ui/combobox/combobox_search_input.rb
+++ b/lib/ruby_ui/combobox/combobox_search_input.rb
@@ -44,7 +44,7 @@ module RubyUI
           "flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
         placeholder: @placeholder,
         data: {
-          action: "input->ruby_ui--combobox#onSearchInput",
+          action: "input->ruby-ui--combobox#onSearchInput",
           ruby_ui__combobox_target: "search"
         },
         autocomplete: "off",

--- a/lib/ruby_ui/combobox/combobox_trigger.rb
+++ b/lib/ruby_ui/combobox/combobox_trigger.rb
@@ -34,7 +34,7 @@ module RubyUI
     def default_attrs
       {
         data: {
-          action: "ruby_ui--combobox#onTriggerClick",
+          action: "ruby-ui--combobox#onTriggerClick",
           ruby_ui__combobox_target: "trigger"
         },
         type: "button",

--- a/lib/ruby_ui/command/command_controller.js
+++ b/lib/ruby_ui/command/command_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "@hotwired/stimulus";
 import Fuse from "fuse.js";
 
-// Connects to data-controller="ruby_ui--command"
+// Connects to data-controller="ruby-ui--command"
 export default class extends Controller {
   static targets = ["input", "group", "item", "empty", "content"];
 
@@ -67,7 +67,7 @@ export default class extends Controller {
     this.groupTargets.forEach((group) => {
       const hasVisibleItems =
         group.querySelectorAll(
-          "[data-ruby_ui--command-target='item']:not(.hidden)",
+          "[data-ruby-ui--command-target='item']:not(.hidden)",
         ).length > 0;
       this.toggleVisibility([group], hasVisibleItems);
     });

--- a/lib/ruby_ui/command/command_dialog.rb
+++ b/lib/ruby_ui/command/command_dialog.rb
@@ -10,7 +10,7 @@ module RubyUI
 
     def default_attrs
       {
-        data: {controller: "ruby_ui--command"}
+        data: {controller: "ruby-ui--command"}
       }
     end
   end

--- a/lib/ruby_ui/command/command_dialog_content.rb
+++ b/lib/ruby_ui/command/command_dialog_content.rb
@@ -18,7 +18,7 @@ module RubyUI
 
     def view_template(&block)
       all_template_tag(data: {ruby_ui__command_target: "content"}) do
-        div(data: {controller: "ruby_ui--command"}) do
+        div(data: {controller: "ruby-ui--command"}) do
           backdrop
           div(**attrs, &block)
         end
@@ -40,7 +40,7 @@ module RubyUI
     def backdrop
       div(
         data_state: "open",
-        data_action: "click->ruby_ui--command#dismiss esc->ruby_ui--command#dismiss",
+        data_action: "click->ruby-ui--command#dismiss esc->ruby-ui--command#dismiss",
         class: "fixed pointer-events-auto inset-0 z-50 bg-background/80 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0"
       )
     end

--- a/lib/ruby_ui/command/command_dialog_trigger.rb
+++ b/lib/ruby_ui/command/command_dialog_trigger.rb
@@ -8,7 +8,7 @@ module RubyUI
     ].freeze
 
     def initialize(keybindings: DEFAULT_KEYBINDINGS, **attrs)
-      @keybindings = keybindings.map { |kb| "#{kb}->ruby_ui--command#open" }
+      @keybindings = keybindings.map { |kb| "#{kb}->ruby-ui--command#open" }
       super(**attrs)
     end
 
@@ -21,7 +21,7 @@ module RubyUI
     def default_attrs
       {
         data: {
-          action: ["click->ruby_ui--command#open", @keybindings.join(" ")]
+          action: ["click->ruby-ui--command#open", @keybindings.join(" ")]
         }
       }
     end

--- a/lib/ruby_ui/command/command_input.rb
+++ b/lib/ruby_ui/command/command_input.rb
@@ -40,7 +40,7 @@ module RubyUI
       {
         class: "flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
         placeholder: @placeholder,
-        data_action: "input->ruby_ui--command#filter keydown.down->ruby_ui--command#handleKeydown keydown.up->ruby_ui--command#handleKeydown keydown.enter->ruby_ui--command#handleKeydown keydown.esc->ruby_ui--command#dismiss",
+        data_action: "input->ruby-ui--command#filter keydown.down->ruby-ui--command#handleKeydown keydown.up->ruby-ui--command#handleKeydown keydown.enter->ruby-ui--command#handleKeydown keydown.esc->ruby-ui--command#dismiss",
         data_ruby_ui__command_target: "input",
         autocomplete: "off",
         autocorrect: "off",

--- a/lib/ruby_ui/context_menu/context_menu.rb
+++ b/lib/ruby_ui/context_menu/context_menu.rb
@@ -17,7 +17,7 @@ module RubyUI
     def default_attrs
       {
         data: {
-          controller: "ruby_ui--context-menu",
+          controller: "ruby-ui--context-menu",
           popover_options_value: @options.to_json
         }
       }

--- a/lib/ruby_ui/context_menu/context_menu_item.rb
+++ b/lib/ruby_ui/context_menu/context_menu_item.rb
@@ -56,7 +56,7 @@ module RubyUI
               "relative flex cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground aria-selected:bg-accent aria-selected:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 pl-8",
         tabindex: "-1",
         data_orientation: "vertical",
-        data_action: "click->ruby_ui--context-menu#close",
+        data_action: "click->ruby-ui--context-menu#close",
         data_ruby_ui__context_menu_target: "menuItem",
         data_disabled: @disabled,
         disabled: @disabled

--- a/lib/ruby_ui/context_menu/context_menu_trigger.rb
+++ b/lib/ruby_ui/context_menu/context_menu_trigger.rb
@@ -12,7 +12,7 @@ module RubyUI
       {
         data: {
           ruby_ui__context_menu_target: "trigger",
-          action: "contextmenu->ruby_ui--context-menu#handleContextMenu"
+          action: "contextmenu->ruby-ui--context-menu#handleContextMenu"
         }
       }
     end

--- a/lib/ruby_ui/dialog/dialog.rb
+++ b/lib/ruby_ui/dialog/dialog.rb
@@ -16,7 +16,7 @@ module RubyUI
     def default_attrs
       {
         data: {
-          controller: "ruby_ui--dialog",
+          controller: "ruby-ui--dialog",
           ruby_ui__dialog_open_value: @open
         }
       }

--- a/lib/ruby_ui/dialog/dialog_content.rb
+++ b/lib/ruby_ui/dialog/dialog_content.rb
@@ -18,7 +18,7 @@ module RubyUI
 
     def view_template
       all_template_tag(data: {ruby_ui__dialog_target: "content"}) do
-        div(data_controller: "ruby_ui--dialog") do
+        div(data_controller: "ruby-ui--dialog") do
           backdrop
           div(**attrs) do
             yield
@@ -44,7 +44,7 @@ module RubyUI
       button(
         type: "button",
         class: "absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground",
-        data_action: "click->ruby_ui--dialog#dismiss"
+        data_action: "click->ruby-ui--dialog#dismiss"
       ) do
         svg(
           width: "15",
@@ -69,7 +69,7 @@ module RubyUI
     def backdrop
       div(
         data_state: "open",
-        data_action: "click->ruby_ui--dialog#dismiss esc->ruby_ui--dialog#dismiss",
+        data_action: "click->ruby-ui--dialog#dismiss esc->ruby-ui--dialog#dismiss",
         class:
               "fixed pointer-events-auto inset-0 z-50 bg-background/80 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0"
       )

--- a/lib/ruby_ui/dialog/dialog_trigger.rb
+++ b/lib/ruby_ui/dialog/dialog_trigger.rb
@@ -11,7 +11,7 @@ module RubyUI
     def default_attrs
       {
         data: {
-          action: "click->ruby_ui--dialog#open"
+          action: "click->ruby-ui--dialog#open"
         },
         class: "inline-block"
       }

--- a/lib/ruby_ui/dropdown_menu/dropdown_menu.rb
+++ b/lib/ruby_ui/dropdown_menu/dropdown_menu.rb
@@ -16,8 +16,8 @@ module RubyUI
     def default_attrs
       {
         data: {
-          controller: "ruby_ui--dropdown-menu",
-          action: "click@window->ruby_ui--dropdown-menu#onClickOutside",
+          controller: "ruby-ui--dropdown-menu",
+          action: "click@window->ruby-ui--dropdown-menu#onClickOutside",
           ruby_ui__dropdown_menu_options_value: @options.to_json
         }
       }

--- a/lib/ruby_ui/dropdown_menu/dropdown_menu_item.rb
+++ b/lib/ruby_ui/dropdown_menu/dropdown_menu_item.rb
@@ -18,7 +18,7 @@ module RubyUI
         href: @href,
         role: "menuitem",
         class: "relative flex cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground aria-selected:bg-accent aria-selected:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
-        data_action: "click->ruby_ui--dropdown-menu#close",
+        data_action: "click->ruby-ui--dropdown-menu#close",
         data_ruby_ui__dropdown_menu_target: "menuItem",
         tabindex: "-1",
         data_orientation: "vertical"

--- a/lib/ruby_ui/dropdown_menu/dropdown_menu_trigger.rb
+++ b/lib/ruby_ui/dropdown_menu/dropdown_menu_trigger.rb
@@ -10,7 +10,7 @@ module RubyUI
 
     def default_attrs
       {
-        data: {ruby_ui__dropdown_menu_target: "trigger", action: "click->ruby_ui--dropdown-menu#toggle"},
+        data: {ruby_ui__dropdown_menu_target: "trigger", action: "click->ruby-ui--dropdown-menu#toggle"},
         class: "inline-block"
       }
     end

--- a/lib/ruby_ui/form/form_field.rb
+++ b/lib/ruby_ui/form/form_field.rb
@@ -11,7 +11,7 @@ module RubyUI
     def default_attrs
       {
         data: {
-          controller: "ruby_ui--form-field"
+          controller: "ruby-ui--form-field"
         },
         class: "space-y-2"
       }

--- a/lib/ruby_ui/hover_card/hover_card.rb
+++ b/lib/ruby_ui/hover_card/hover_card.rb
@@ -18,7 +18,7 @@ module RubyUI
     def default_attrs
       {
         data: {
-          controller: "ruby_ui--hover-card",
+          controller: "ruby-ui--hover-card",
           ruby_ui__hover_card_options_value: @options.to_json
         }
       }

--- a/lib/ruby_ui/index.js
+++ b/lib/ruby_ui/index.js
@@ -34,31 +34,31 @@ function initialize(application) {
   };
 
   // Register all controllers
-  registerIfNotExists("ruby_ui--accordion", AccordionController);
-  registerIfNotExists("ruby_ui--alert-dialog", AlertDialogController);
-  registerIfNotExists("ruby_ui--calendar", CalendarController);
-  registerIfNotExists("ruby_ui--calendar-input", CalendarInputController);
-  registerIfNotExists("ruby_ui--collapsible", CollapsibleController);
-  registerIfNotExists("ruby_ui--chart", ChartController);
-  registerIfNotExists("ruby_ui--checkbox-group", CheckboxGroupController);
-  registerIfNotExists("ruby_ui--clipboard", ClipboardController);
-  registerIfNotExists("ruby_ui--combobox", ComboboxController);
-  registerIfNotExists("ruby_ui--combobox-content", ComboboxContentController);
-  registerIfNotExists("ruby_ui--combobox-item", ComboboxItemController);
-  registerIfNotExists("ruby_ui--command", CommandController);
-  registerIfNotExists("ruby_ui--context-menu", ContextMenuController);
-  registerIfNotExists("ruby_ui--dialog", DialogController);
-  registerIfNotExists("ruby_ui--dropdown-menu", DropdownMenuController);
-  registerIfNotExists("ruby_ui--form-field", FormFieldController);
-  registerIfNotExists("ruby_ui--hover-card", HoverCardController);
-  registerIfNotExists("ruby_ui--popover", PopoverController);
-  registerIfNotExists("ruby_ui--tabs", TabsController);
-  registerIfNotExists("ruby_ui--theme-toggle", ThemeToggleController);
-  registerIfNotExists("ruby_ui--tooltip", TooltipController);
-  registerIfNotExists("ruby_ui--select", SelectController);
-  registerIfNotExists("ruby_ui--select-item", SelectItemController);
-  registerIfNotExists("ruby_ui--sheet", SheetController);
-  registerIfNotExists("ruby_ui--sheet-content", SheetContentController);
+  registerIfNotExists("ruby-ui--accordion", AccordionController);
+  registerIfNotExists("ruby-ui--alert-dialog", AlertDialogController);
+  registerIfNotExists("ruby-ui--calendar", CalendarController);
+  registerIfNotExists("ruby-ui--calendar-input", CalendarInputController);
+  registerIfNotExists("ruby-ui--collapsible", CollapsibleController);
+  registerIfNotExists("ruby-ui--chart", ChartController);
+  registerIfNotExists("ruby-ui--checkbox-group", CheckboxGroupController);
+  registerIfNotExists("ruby-ui--clipboard", ClipboardController);
+  registerIfNotExists("ruby-ui--combobox", ComboboxController);
+  registerIfNotExists("ruby-ui--combobox-content", ComboboxContentController);
+  registerIfNotExists("ruby-ui--combobox-item", ComboboxItemController);
+  registerIfNotExists("ruby-ui--command", CommandController);
+  registerIfNotExists("ruby-ui--context-menu", ContextMenuController);
+  registerIfNotExists("ruby-ui--dialog", DialogController);
+  registerIfNotExists("ruby-ui--dropdown-menu", DropdownMenuController);
+  registerIfNotExists("ruby-ui--form-field", FormFieldController);
+  registerIfNotExists("ruby-ui--hover-card", HoverCardController);
+  registerIfNotExists("ruby-ui--popover", PopoverController);
+  registerIfNotExists("ruby-ui--tabs", TabsController);
+  registerIfNotExists("ruby-ui--theme-toggle", ThemeToggleController);
+  registerIfNotExists("ruby-ui--tooltip", TooltipController);
+  registerIfNotExists("ruby-ui--select", SelectController);
+  registerIfNotExists("ruby-ui--select-item", SelectItemController);
+  registerIfNotExists("ruby-ui--sheet", SheetController);
+  registerIfNotExists("ruby-ui--sheet-content", SheetContentController);
 }
 
 const RubyUI = {

--- a/lib/ruby_ui/input/input.rb
+++ b/lib/ruby_ui/input/input.rb
@@ -17,7 +17,7 @@ module RubyUI
       {
         data: {
           ruby_ui__form_field_target: "input",
-          action: "input->ruby_ui--form-field#onInput invalid->ruby_ui--form-field#onInvalid"
+          action: "input->ruby-ui--form-field#onInput invalid->ruby-ui--form-field#onInvalid"
         },
         class: "flex h-9 w-full rounded-md border bg-background px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:outline-none focus-visible:ring-1 disabled:cursor-not-allowed disabled:opacity-50 border-border focus-visible:ring-ring placeholder:text-muted-foreground"
       }

--- a/lib/ruby_ui/popover/popover.rb
+++ b/lib/ruby_ui/popover/popover.rb
@@ -16,7 +16,7 @@ module RubyUI
     def default_attrs
       {
         data: {
-          controller: "ruby_ui--popover",
+          controller: "ruby-ui--popover",
           ruby_ui__popover_options_value: @options.to_json,
           ruby_ui__popover_trigger_value: @options[:trigger] || "hover"
         }

--- a/lib/ruby_ui/radio_button/radio_button.rb
+++ b/lib/ruby_ui/radio_button/radio_button.rb
@@ -13,7 +13,7 @@ module RubyUI
         type: "radio",
         data: {
           ruby_ui__form_field_target: "input",
-          action: "change->ruby_ui--form-field#onInput invalid->ruby_ui--form-field#onInvalid"
+          action: "change->ruby-ui--form-field#onInput invalid->ruby-ui--form-field#onInvalid"
         },
         class: "h-4 w-4 p-0 border-primary rounded-full flex-none"
       }

--- a/lib/ruby_ui/select/select.rb
+++ b/lib/ruby_ui/select/select.rb
@@ -11,9 +11,9 @@ module RubyUI
     def default_attrs
       {
         data: {
-          controller: "ruby_ui--select",
+          controller: "ruby-ui--select",
           ruby_ui__select_open_value: "false",
-          action: "click@window->ruby_ui--select#clickOutside",
+          action: "click@window->ruby-ui--select#clickOutside",
           ruby_ui__select_ruby_ui__select_item_outlet: ".item"
         },
         class: "group/select w-full relative"

--- a/lib/ruby_ui/select/select_content.rb
+++ b/lib/ruby_ui/select/select_content.rb
@@ -10,7 +10,7 @@ module RubyUI
     def view_template(&block)
       div(**attrs) do
         div(
-          class: "max-h-96 min-w-max overflow-auto rounded-md border bg-background p-1 text-foreground shadow-md animate-out group-data-[ruby_ui--select-open-value=true]/select:animate-in fade-out-0 group-data-[ruby_ui--select-open-value=true]/select:fade-in-0 zoom-out-95 group-data-[ruby_ui--select-open-value=true]/select:zoom-in-95 slide-in-from-top-2", &block
+          class: "max-h-96 min-w-max overflow-auto rounded-md border bg-background p-1 text-foreground shadow-md animate-out group-data-[ruby-ui--select-open-value=true]/select:animate-in fade-out-0 group-data-[ruby-ui--select-open-value=true]/select:fade-in-0 zoom-out-95 group-data-[ruby-ui--select-open-value=true]/select:zoom-in-95 slide-in-from-top-2", &block
         )
       end
     end

--- a/lib/ruby_ui/select/select_controller.js
+++ b/lib/ruby_ui/select/select_controller.js
@@ -4,7 +4,7 @@ import { computePosition, autoUpdate, offset } from "@floating-ui/dom";
 export default class extends Controller {
   static targets = ["trigger", "content", "input", "value", "item"];
   static values = { open: Boolean };
-  static outlets = ["ruby_ui--select-item"];
+  static outlets = ["ruby-ui--select-item"];
 
   constructor(...args) {
     super(...args);

--- a/lib/ruby_ui/select/select_input.rb
+++ b/lib/ruby_ui/select/select_input.rb
@@ -14,7 +14,7 @@ module RubyUI
         data: {
           ruby_ui__select_target: "input",
           ruby_ui__form_field_target: "input",
-          action: "change->ruby_ui--form-field#onChange invalid->ruby_ui--form-field#onInvalid"
+          action: "change->ruby-ui--form-field#onChange invalid->ruby-ui--form-field#onInvalid"
         }
       }
     end

--- a/lib/ruby_ui/select/select_item.rb
+++ b/lib/ruby_ui/select/select_item.rb
@@ -39,8 +39,8 @@ module RubyUI
         tabindex: "0",
         class: "item group relative flex cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground aria-selected:bg-accent aria-selected:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
         data: {
-          controller: "ruby_ui--select-item",
-          action: "click->ruby_ui--select#selectItem keydown.enter->ruby_ui--select#selectItem keydown.down->ruby_ui--select#handleKeyDown keydown.up->ruby_ui--select#handleKeyUp keydown.esc->ruby_ui--select#handleEsc",
+          controller: "ruby-ui--select-item",
+          action: "click->ruby-ui--select#selectItem keydown.enter->ruby-ui--select#selectItem keydown.down->ruby-ui--select#handleKeyDown keydown.up->ruby-ui--select#handleKeyUp keydown.esc->ruby-ui--select#handleEsc",
           ruby_ui__select_target: "item"
         },
         data_value: @value,

--- a/lib/ruby_ui/select/select_trigger.rb
+++ b/lib/ruby_ui/select/select_trigger.rb
@@ -34,7 +34,7 @@ module RubyUI
     def default_attrs
       {
         data: {
-          action: "ruby_ui--select#onClick",
+          action: "ruby-ui--select#onClick",
           ruby_ui__select_target: "trigger"
         },
         type: "button",

--- a/lib/ruby_ui/sheet/sheet.rb
+++ b/lib/ruby_ui/sheet/sheet.rb
@@ -10,7 +10,7 @@ module RubyUI
 
     def default_attrs
       {
-        data: {controller: "ruby_ui--sheet"}
+        data: {controller: "ruby-ui--sheet"}
       }
     end
   end

--- a/lib/ruby_ui/sheet/sheet_content.rb
+++ b/lib/ruby_ui/sheet/sheet_content.rb
@@ -17,7 +17,7 @@ module RubyUI
 
     def view_template(&block)
       all_template_tag(data: {ruby_ui__sheet_target: "content"}) do
-        div(data: {controller: "ruby_ui--sheet-content"}) do
+        div(data: {controller: "ruby-ui--sheet-content"}) do
           backdrop
           div(**attrs) do
             block&.call
@@ -43,7 +43,7 @@ module RubyUI
       button(
         type: "button",
         class: "absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground",
-        data_action: "click->ruby_ui--sheet-content#close"
+        data_action: "click->ruby-ui--sheet-content#close"
       ) do
         svg(
           width: "15",
@@ -68,7 +68,7 @@ module RubyUI
     def backdrop
       div(
         data_state: "open",
-        data_action: "click->ruby_ui--sheet-content#close",
+        data_action: "click->ruby-ui--sheet-content#close",
         class:
               "fixed pointer-events-auto inset-0 z-50 bg-background/80 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0"
       )

--- a/lib/ruby_ui/sheet/sheet_trigger.rb
+++ b/lib/ruby_ui/sheet/sheet_trigger.rb
@@ -10,7 +10,7 @@ module RubyUI
 
     def default_attrs
       {
-        data: {action: "click->ruby_ui--sheet#open"}
+        data: {action: "click->ruby-ui--sheet#open"}
       }
     end
   end

--- a/lib/ruby_ui/tabs/tabs.rb
+++ b/lib/ruby_ui/tabs/tabs.rb
@@ -16,7 +16,7 @@ module RubyUI
     def default_attrs
       {
         data: {
-          controller: "ruby_ui--tabs",
+          controller: "ruby-ui--tabs",
           ruby_ui__tabs_active_value: @default
         }
       }

--- a/lib/ruby_ui/tabs/tabs_controller.js
+++ b/lib/ruby_ui/tabs/tabs_controller.js
@@ -1,6 +1,6 @@
 import { Controller } from "@hotwired/stimulus";
 
-// Connects to data-controller="ruby_ui--tabs"
+// Connects to data-controller="ruby-ui--tabs"
 export default class extends Controller {
   static targets = ["trigger", "content"];
   static values = { active: String };

--- a/lib/ruby_ui/tabs/tabs_trigger.rb
+++ b/lib/ruby_ui/tabs/tabs_trigger.rb
@@ -18,7 +18,7 @@ module RubyUI
         type: :button,
         data: {
           ruby_ui__tabs_target: "trigger",
-          action: "click->ruby_ui--tabs#show",
+          action: "click->ruby-ui--tabs#show",
           value: @value
         },
         class: "inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow"

--- a/lib/ruby_ui/textarea/textarea.rb
+++ b/lib/ruby_ui/textarea/textarea.rb
@@ -17,7 +17,7 @@ module RubyUI
       {
         data: {
           ruby_ui__form_field_target: "input",
-          action: "input->ruby_ui--form-field#onInput invalid->ruby_ui--form-field#onInvalid"
+          action: "input->ruby-ui--form-field#onInput invalid->ruby-ui--form-field#onInvalid"
         },
         class: "flex w-full rounded-md border bg-background px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:outline-none focus-visible:ring-1 disabled:cursor-not-allowed disabled:opacity-50 border-border focus-visible:ring-ring placeholder:text-muted-foreground"
       }

--- a/lib/ruby_ui/theme_toggle/theme_toggle.rb
+++ b/lib/ruby_ui/theme_toggle/theme_toggle.rb
@@ -20,21 +20,21 @@ module RubyUI
 
     def default_attrs
       {
-        data: {controller: "ruby_ui--theme-toggle"}
+        data: {controller: "ruby-ui--theme-toggle"}
       }
     end
 
     def default_light_attrs
       {
         class: "dark:hidden",
-        data: {action: "click->ruby_ui--theme-toggle#setDarkTheme"}
+        data: {action: "click->ruby-ui--theme-toggle#setDarkTheme"}
       }
     end
 
     def default_dark_attrs
       {
         class: "hidden dark:inline-block",
-        data: {action: "click->ruby_ui--theme-toggle#setLightTheme"}
+        data: {action: "click->ruby-ui--theme-toggle#setLightTheme"}
       }
     end
   end

--- a/lib/ruby_ui/tooltip/tooltip.rb
+++ b/lib/ruby_ui/tooltip/tooltip.rb
@@ -16,7 +16,7 @@ module RubyUI
     def default_attrs
       {
         data: {
-          controller: "ruby_ui--tooltip",
+          controller: "ruby-ui--tooltip",
           ruby_ui__tooltip_placement_value: @placement
         },
         class: "group"

--- a/lib/ruby_ui/tooltip/tooltip_content.rb
+++ b/lib/ruby_ui/tooltip/tooltip_content.rb
@@ -19,7 +19,7 @@ module RubyUI
         data: {
           ruby_ui__tooltip_target: "content"
         },
-        class: "invisible peer-hover:visible peer-focus:visible w-max absolute top-0 left-0 z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md peer-focus:zoom-in-95 animate-out fade-out-0 zoom-out-95 peer-hover:animate-in peer-focus:animate-in peer-hover:fade-in-0 peer-focus:fade-in-0 peer-hover:zoom-in-95 group-data-[ruby_ui--tooltip-placement-value=bottom]:slide-in-from-top-2 group-data-[ruby_ui--tooltip-placement-value=left]:slide-in-from-right-2 group-data-[ruby_ui--tooltip-placement-value=right]:slide-in-from-left-2 group-data-[ruby_ui--tooltip-placement-value=top]:slide-in-from-bottom-2 delay-500"
+        class: "invisible peer-hover:visible peer-focus:visible w-max absolute top-0 left-0 z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md peer-focus:zoom-in-95 animate-out fade-out-0 zoom-out-95 peer-hover:animate-in peer-focus:animate-in peer-hover:fade-in-0 peer-focus:fade-in-0 peer-hover:zoom-in-95 group-data-[ruby-ui--tooltip-placement-value=bottom]:slide-in-from-top-2 group-data-[ruby-ui--tooltip-placement-value=left]:slide-in-from-right-2 group-data-[ruby-ui--tooltip-placement-value=right]:slide-in-from-left-2 group-data-[ruby-ui--tooltip-placement-value=top]:slide-in-from-bottom-2 delay-500"
       }
     end
   end

--- a/test/ruby_ui/accordion_test.rb
+++ b/test/ruby_ui/accordion_test.rb
@@ -15,7 +15,7 @@ class RubyUI::AccordionTest < Minitest::Test
       end
     end
 
-    assert_match(/<div data-controller="ruby_ui--accordion"/, output)
+    assert_match(/<div data-controller="ruby-ui--accordion"/, output)
   end
 
   def test_render_with_all_items

--- a/test/ruby_ui/calendar_test.rb
+++ b/test/ruby_ui/calendar_test.rb
@@ -7,7 +7,7 @@ class RubyUI::CalendarTest < Minitest::Test
 
   def test_render_with_all_items
     output = phlex_context do
-      RubyUI.Input(type: "string", placeholder: "Select a date", class: "rounded-md border shadow", id: "date", data_controller: "ruby_ui--input")
+      RubyUI.Input(type: "string", placeholder: "Select a date", class: "rounded-md border shadow", id: "date", data_controller: "ruby-ui--input")
       RubyUI.Calendar(input_id: "#date", class: "rounded-md border shadow")
     end
 

--- a/test/ruby_ui/dialog_test.rb
+++ b/test/ruby_ui/dialog_test.rb
@@ -26,7 +26,7 @@ class RubyUI::DialogTest < Minitest::Test
             end
           end
           RubyUI.DialogFooter do
-            RubyUI.Button(variant: :outline, data: {action: "click->ruby_ui--dialog#dismiss"}) { "Cancel" }
+            RubyUI.Button(variant: :outline, data: {action: "click->ruby-ui--dialog#dismiss"}) { "Cancel" }
             RubyUI.Button { "Save" }
           end
         end

--- a/test/ruby_ui/sheet_test.rb
+++ b/test/ruby_ui/sheet_test.rb
@@ -22,7 +22,7 @@ class RubyUI::SheetTest < Minitest::Test
             RubyUI.Input(placeholder: "joel@drapper.me")
 
             RubyUI.SheetFooter do
-              RubyUI.Button(variant: :outline, data: {action: "click->ruby_ui--sheet-content#close"}) { "Cancel" }
+              RubyUI.Button(variant: :outline, data: {action: "click->ruby-ui--sheet-content#close"}) { "Cancel" }
               RubyUI.Button(type: "submit") { "Save" }
             end
           end


### PR DESCRIPTION
https://github.com/ruby-ui/ruby_ui/pull/179 follow up.

The `ruby_ui__accordion_target: "foo"` will become `ruby-ui--accordion-target="foo"`, so using `ruby_ui--accordion_target` as controller name would break a lot of components (eg. I could not merge https://github.com/ruby-ui/web/pull/128 because when I point to rubyui main, all the component pages are broken). 