### PR TITLE
fix `ruby_ui-js` refs

### DIFF
--- a/lib/generators/ruby_ui/install/install_generator.rb
+++ b/lib/generators/ruby_ui/install/install_generator.rb
@@ -92,10 +92,10 @@ module RubyUI
 
         def pin_ruby_ui_js
           stimulus_path = Rails.root.join("app/javascript/application.js")
-          package_name = "ruby_ui-js"
+          package_name = "ruby_ui_js"
 
           say "Add RubyUI Stimulus controllers"
-          # run "mkdir -p app/javascript/controllers/ruby_ui-js"
+          # run "mkdir -p app/javascript/controllers/ruby_ui_js"
           template "index.js", "app/components/ruby_ui/index.js"
 
           if using_importmap?
@@ -122,7 +122,7 @@ module RubyUI
 
             fix_import_maps!
           else
-            say "Add ruby_ui-js package"
+            say "Add ruby_ui_js package"
             run "yarn add #{package_name}"
 
             append_to_file stimulus_path, "\nimport \"../components/ruby_ui\";\n"

--- a/lib/generators/ruby_ui/install/templates/index.js.tt
+++ b/lib/generators/ruby_ui/install/templates/index.js.tt
@@ -6,5 +6,5 @@ import { application } from "../../../app/javascript/controllers/application";
 // Register all controllers
 // application.register("ruby-ui--combobox", ComboboxController);
 
-import RubyUI from "ruby_ui-js";
+import RubyUI from "ruby_ui_js";
 RubyUI.initialize(application);


### PR DESCRIPTION
In the install generator, there are still some references to the old `ruby_ui-js` name for the NPM package. This PR updates it to `ruby_ui_js`.