### PR TITLE
Change Codeblock tab size

### DIFF
--- a/lib/ruby_ui/codeblock/codeblock.rb
+++ b/lib/ruby_ui/codeblock/codeblock.rb
@@ -34,6 +34,7 @@ module RubyUI
 
     def default_attrs
       {
+        style: {tab_size: 2},
         class: "highlight text-sm max-h-[350px] after:content-none flex font-mono overflow-auto overflow-x rounded-md border !bg-stone-900 [&_pre]:p-4"
       }
     end


### PR DESCRIPTION
Change codeblock tab size to 2. I think it is a good default value. I couldn't find a tailwind class to change tabsize, so I added an inline style to Codeblock.
Before:
<img width="531" alt="Screenshot 2024-11-11 at 16 48 11" src="https://github.com/user-attachments/assets/b11c9adf-ce92-4ca2-ba7e-098244b52414">

After:
<img width="522" alt="Screenshot 2024-11-11 at 16 48 04" src="https://github.com/user-attachments/assets/81e1d828-f057-4920-8d9c-17c811d3c59c">
