### PR TITLE
Fix AlertDialog controller reference

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/ruby
 {
-  "name": "RbUI",
+  "name": "RubyUI",
   // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
   "image": "ghcr.io/rails/devcontainer/images/ruby:3.3.3",
   // Features to add to the dev container. More info: https://containers.dev/features.

--- a/lib/ruby_ui/alert_dialog/alert_dialog_content.rb
+++ b/lib/ruby_ui/alert_dialog/alert_dialog_content.rb
@@ -4,7 +4,7 @@ module RubyUI
   class AlertDialogContent < Base
     def view_template(&block)
       template(**attrs) do
-        div(data: {controller: "rbui--alert-dialog"}) do
+        div(data: {controller: "ruby-ui--alert-dialog"}) do
           background
           container(&block)
         end


### PR DESCRIPTION
AlertDialog is using `rbui` controller, so it isn't working (it is possible to verify here: https://rubyui.com/docs/alert_dialog, the cancel button isn't working.

I think this PR removes the last references to RBUI.