### PR TITLE
Fix ruby ui outlets access

### DIFF
--- a/lib/ruby_ui/calendar/calendar_controller.js
+++ b/lib/ruby_ui/calendar/calendar_controller.js
@@ -57,7 +57,7 @@ export default class extends Controller {
     this.updateCalendar();
 
     // update the input value
-    this.ruby_uiCalendarInputOutlets.forEach((outlet) => {
+    this.rubyUiCalendarInputOutlets.forEach((outlet) => {
       const formattedDate = this.formatDate(this.selectedDate());
       outlet.setValue(formattedDate);
     });

--- a/lib/ruby_ui/combobox/combobox_controller.js
+++ b/lib/ruby_ui/combobox/combobox_controller.js
@@ -59,7 +59,7 @@ export default class extends Controller {
   }
 
   onSearchInput(event) {
-    this.ruby_uiComboboxContentOutlet.handleSearchInput(event.target.value);
+    this.rubyUiComboboxContentOutlet.handleSearchInput(event.target.value);
     this.#findAndSetCurrentAndActiveDescendant();
   }
 
@@ -155,7 +155,7 @@ export default class extends Controller {
     const oldValue = this.inputTarget.value;
     const newValue = item.dataset.value;
 
-    this.ruby_uiComboboxItemOutlets.forEach((item) =>
+    this.rubyUiComboboxItemOutlets.forEach((item) =>
       item.handleItemSelected(newValue),
     );
 

--- a/lib/ruby_ui/select/select_controller.js
+++ b/lib/ruby_ui/select/select_controller.js
@@ -23,7 +23,7 @@ export default class extends Controller {
   selectItem(event) {
     event.preventDefault();
 
-    this.ruby_uiSelectItemOutlets.forEach((item) =>
+    this.rubyUiSelectItemOutlets.forEach((item) =>
       item.handleSelectItem(event),
     );
 


### PR DESCRIPTION
As pointed by @pierry01 , select component isn't working. This is because outlets should be accessed using `rubyUi` prefix instead of `ruby_ui`.