### PR TITLE
Install component dependencies (gems, stimulus, packages, components)

### DIFF
--- a/lib/generators/ruby_ui/component_generator.rb
+++ b/lib/generators/ruby_ui/component_generator.rb
@@ -53,7 +53,6 @@ module RubyUI
         say "Installing dependencies"
 
         install_components_dependencies(dependencies["components"])
-        install_stimulus_dependencies(dependencies["stimulus_controllers"])
         install_gems_dependencies(dependencies["gems"])
         install_js_packages(dependencies["js_packages"])
       end
@@ -76,18 +75,6 @@ module RubyUI
         components&.each do |component|
           run "bin/rails generate ruby_ui:component #{component}"
         end
-      end
-
-      def install_stimulus_dependencies(stimulus_controllers)
-        return if stimulus_controllers.nil?
-
-        stimulus_controllers.each do |controller|
-          controller_path = File.join(self.class.source_root, controller)
-          controller_file_name = controller.split("/").last
-          copy_file controller_path, Rails.root.join("app/javascript/controllers/ruby_ui", controller_file_name)
-        end
-
-        run "rake stimulus:manifest:update"
       end
 
       def install_gems_dependencies(gems)

--- a/lib/generators/ruby_ui/dependencies.yml
+++ b/lib/generators/ruby_ui/dependencies.yml
@@ -14,10 +14,6 @@ chart:
   js_packages:
     - "chart.js"
 
-checkbox:
-  stimulus_controllers:
-    - "form/form_field_controller.js"
-
 clipboard:
   js_packages:
     - "@floating-ui/dom"
@@ -33,9 +29,6 @@ codeblock:
 combobox:
   js_packages:
     - "@floating-ui/dom"
-
-  stimulus_controllers:
-    - "form/form_field_controller.js"
 
 command:
   js_packages:
@@ -53,10 +46,6 @@ hover_card:
   js_packages:
     - "tippy.js"
 
-input:
-  stimulus_controllers:
-    - "form/form_field_controller.js"
-
 masked_input:
   components:
     - "Input"
@@ -72,20 +61,9 @@ popover:
   js_packages:
     - "@floating-ui/dom"
 
-radio_button:
-  stimulus_controllers:
-    - "form/form_field_controller.js"
-
 select:
   js_packages:
     - "@floating-ui/dom"
-
-  stimulus_controllers:
-    - "form/form_field_controller.js"
-
-textarea:
-  stimulus_controllers:
-    - "form/form_field_controller.js"
 
 tooltip:
   js_packages:


### PR DESCRIPTION
Improve component generator allowing installing dependencies like another components, js packages, stimulus controllers and ruby gems.
These dependencies are tracked in `dependencies.yml` file, maybe we could try to analyze component files to discover dependencies, but for now I think it will be simpler to add the dependencies manually to the yaml file.

This is an example of an application that RubyUI and Combobox was installed using only our generators (`rails g ruby_ui:install` and `rails g ruby_ui:component Combobox`). It is working 🥳.

https://github.com/user-attachments/assets/357313d8-7b87-4a23-a11d-a892be272a19

