### PR TITLE
Add tailwindcss-animate config

### DIFF
--- a/lib/generators/ruby_ui/component_generator.rb
+++ b/lib/generators/ruby_ui/component_generator.rb
@@ -1,6 +1,9 @@
+require_relative "javascript_utils"
 module RubyUI
   module Generators
     class ComponentGenerator < Rails::Generators::Base
+      include RubyUI::Generators::JavascriptUtils
+
       namespace "ruby_ui:component"
 
       source_root File.expand_path("../../ruby_ui", __dir__)
@@ -92,29 +95,6 @@ module RubyUI
         end
       end
 
-      def install_js_package(package)
-        if using_importmap?
-          pin_with_importmap(package)
-        elsif using_yarn?
-          run "yarn add #{package}"
-        elsif using_npm?
-          run "npm install #{package}"
-        else
-          say "Could not detect the package manager, you need to install '#{package}' manually", :red
-        end
-      end
-
-      def pin_with_importmap(package)
-        case package
-        when "motion"
-          pin_motion
-        when "tippy.js"
-          pin_tippy_js
-        else
-          run "bin/importmap pin #{package}"
-        end
-      end
-
       def pin_motion
         say <<~TEXT
           WARNING: Installing motion from CDN because `bin/importmap pin motion` doesn't download the correct file.
@@ -141,14 +121,6 @@ module RubyUI
 
         @dependencies[component_folder_name]
       end
-
-      def using_importmap?
-        File.exist?(Rails.root.join("config/importmap.rb")) && File.exist?(Rails.root.join("bin/importmap"))
-      end
-
-      def using_npm? = File.exist?(Rails.root.join("package-lock.json"))
-
-      def using_yarn? = File.exist?(Rails.root.join("yarn.lock"))
     end
   end
 end

--- a/lib/generators/ruby_ui/install/install_generator.rb
+++ b/lib/generators/ruby_ui/install/install_generator.rb
@@ -1,8 +1,11 @@
 require "rails/generators"
+require_relative "../javascript_utils"
 
 module RubyUI
   module Generators
     class InstallGenerator < Rails::Generators::Base
+      include RubyUI::Generators::JavascriptUtils
+
       namespace "ruby_ui:install"
 
       source_root File.expand_path("templates", __dir__)
@@ -64,6 +67,12 @@ module RubyUI
         else
           say "Cannot find tailwind.config.js. You will need to install tailwind config manually", :red
         end
+      end
+
+      def install_tailwind_animate
+        say "Installing tailwindcss-animate plugin"
+
+        install_js_package("tailwindcss-animate")
       end
 
       def add_ruby_ui_base

--- a/lib/generators/ruby_ui/install/templates/tailwind.config.js.js-package.erb
+++ b/lib/generators/ruby_ui/install/templates/tailwind.config.js.js-package.erb
@@ -71,4 +71,7 @@ module.exports = {
       },
     },
   },
+  plugins: [
+    require("tailwindcss-animate"),
+  ],
 }

--- a/lib/generators/ruby_ui/install/templates/tailwind.config.js.tailwindcss-rails.erb
+++ b/lib/generators/ruby_ui/install/templates/tailwind.config.js.tailwindcss-rails.erb
@@ -77,5 +77,6 @@ module.exports = {
     require('@tailwindcss/forms'),
     require('@tailwindcss/typography'),
     require('@tailwindcss/container-queries'),
+    require("../vendor/javascript/tailwindcss-animate")
   ]
 }

--- a/lib/generators/ruby_ui/javascript_utils.rb
+++ b/lib/generators/ruby_ui/javascript_utils.rb
@@ -1,0 +1,36 @@
+module RubyUI
+  module Generators
+    module JavascriptUtils
+      def install_js_package(package)
+        if using_importmap?
+          pin_with_importmap(package)
+        elsif using_yarn?
+          run "yarn add #{package}"
+        elsif using_npm?
+          run "npm install #{package}"
+        else
+          say "Could not detect the package manager, you need to install '#{package}' manually", :red
+        end
+      end
+
+      def pin_with_importmap(package)
+        case package
+        when "motion"
+          pin_motion
+        when "tippy.js"
+          pin_tippy_js
+        else
+          run "bin/importmap pin #{package}"
+        end
+      end
+
+      def using_importmap?
+        File.exist?(Rails.root.join("config/importmap.rb")) && File.exist?(Rails.root.join("bin/importmap"))
+      end
+
+      def using_npm? = File.exist?(Rails.root.join("package-lock.json"))
+
+      def using_yarn? = File.exist?(Rails.root.join("yarn.lock"))
+    end
+  end
+end


### PR DESCRIPTION
Adding tailwindcss-animate plugin back to setup installer and moving logic related to javascript packages to a separated module.