### PR TITLE
Switch component implemented

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ bin/rails g ruby_ui:install
 
 ## Documentation 📖
 
-Visit https://rbui.dev/docs/introduction to view the full documentation, including:
+Visit https://rubyui.com/docs/introduction to view the full documentation, including:
 
 - Detailed component guides
 - Themes

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ bin/rails g ruby_ui:install
 
 ## Documentation 📖
 
-Visit https://ruby_ui.dev/docs/introduction to view the full documentation, including:
+Visit https://rbui.dev/docs/introduction to view the full documentation, including:
 
 - Detailed component guides
 - Themes

--- a/lib/ruby_ui/switch/switch.rb
+++ b/lib/ruby_ui/switch/switch.rb
@@ -2,29 +2,23 @@
 
 module RubyUI
   class Switch < Base
-    def view_template
-      attrs => { include_hidden:, **input_attrs }
+    def initialize(include_hidden: true, checked_value: "1", unchecked_value: "0", **attrs)
+      @include_hidden = include_hidden
+      @checked_value = checked_value
+      @unchecked_value = unchecked_value
+      super(**attrs)
+    end
 
+    def view_template
       label(
         role: "switch",
         class: "peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background has-[:disabled]:cursor-not-allowed has-[:disabled]:opacity-50 bg-input has-[:checked]:bg-primary"
       ) do
-        input(type: "hidden", name: attrs[:name], value: "0") if include_hidden
-        input(**input_attrs)
+        input(type: "hidden", name: attrs[:name], value: @unchecked_value) if @include_hidden
+        input(**attrs.merge(type: "checkbox", class: "hidden peer", value: @checked_value))
 
         span(class: "pointer-events-none block h-5 w-5 rounded-full bg-background shadow-lg ring-0 transition-transform translate-x-0 peer-checked:translate-x-5 ")
       end
-    end
-
-    private
-
-    def default_attrs
-      {
-        class: "hidden peer",
-        type: "checkbox",
-        include_hidden: true,
-        value: "1"
-      }
     end
   end
 end

--- a/lib/ruby_ui/switch/switch.rb
+++ b/lib/ruby_ui/switch/switch.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module RubyUI
+  class Switch < Base
+    def view_template
+      attrs => { include_hidden:, **input_attrs }
+
+      label(
+        role: "switch",
+        class: "peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background has-[:disabled]:cursor-not-allowed has-[:disabled]:opacity-50 bg-input has-[:checked]:bg-primary"
+      ) do
+        input(type: "hidden", name: attrs[:name], value: "0") if include_hidden
+        input(**input_attrs)
+
+        span(class: "pointer-events-none block h-5 w-5 rounded-full bg-background shadow-lg ring-0 transition-transform translate-x-0 peer-checked:translate-x-5 ")
+      end
+    end
+
+    private
+
+    def default_attrs
+      {
+        class: "hidden peer",
+        type: "checkbox",
+        include_hidden: true,
+        value: "1"
+      }
+    end
+  end
+end

--- a/test/ruby_ui/switch_test.rb
+++ b/test/ruby_ui/switch_test.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class RubyUI::SwitchTest < ComponentTest
+  def test_render_with_all_items
+    output = phlex do
+      RubyUI.Switch(name: "toggle")
+    end
+
+    assert_match(/toggle/, output)
+  end
+
+  def test_render_checked
+    output = phlex do
+      RubyUI.Switch(name: "toggle", checked: true)
+    end
+
+    assert_match(/checked/, output)
+  end
+end


### PR DESCRIPTION
Implemented Switch component base in the ShadCn styles but using the pseudo-classes to style the componente based in the checked state of the hidden input.

One design decision that is up to debate is the inclusion of the flag include_hidden inspired by the Rail's [checkbox](https://api.rubyonrails.org/classes/ActionView/Helpers/FormHelper.html#method-i-checkbox) implementation to avoid sending no value on form submission when the switch is off.

Here are the examples to ruby-ui/web:
<img width="763" alt="Screenshot 2024-11-22 at 12 32 01" src="https://github.com/user-attachments/assets/4ae1901c-c7eb-4df5-88d5-35d1fd7204d5">
<img width="713" alt="Screenshot 2024-11-22 at 12 32 20" src="https://github.com/user-attachments/assets/29235ed4-256e-4fec-a229-3fee17a5964f">
