### PR TITLE
Add breadcrumb component

### DIFF
--- a/lib/ruby_ui/breadcrumb/breadcrumb.rb
+++ b/lib/ruby_ui/breadcrumb/breadcrumb.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module RubyUI
+  class Breadcrumb < Base
+    def view_template(&)
+      nav(**attrs, &)
+    end
+
+    private
+
+    def default_attrs
+      {
+        aria: {label: "breadcrumb"}
+      }
+    end
+  end
+end

--- a/lib/ruby_ui/breadcrumb/breadcrumb_ellipsis.rb
+++ b/lib/ruby_ui/breadcrumb/breadcrumb_ellipsis.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module RubyUI
+  class BreadcrumbEllipsis < Base
+    def view_template(&)
+      span(**attrs) do
+        icon
+        span(class: "sr-only") { "More" }
+      end
+    end
+
+    private
+
+    def icon
+      svg(
+        xmlns: "http://www.w3.org/2000/svg",
+        class: "w-4 h-4",
+        viewbox: "0 0 24 24",
+        fill: "none",
+        stroke: "currentColor",
+        stroke_width: "2",
+        stroke_linecap: "round",
+        stroke_linejoin: "round"
+      ) do |s|
+        s.circle(cx: "12", cy: "12", r: "1")
+        s.circle(cx: "19", cy: "12", r: "1")
+        s.circle(cx: "5", cy: "12", r: "1")
+      end
+    end
+
+    def default_attrs
+      {
+        aria: {hidden: true},
+        class: "flex h-9 w-9 items-center justify-center",
+        role: "presentation"
+      }
+    end
+  end
+end

--- a/lib/ruby_ui/breadcrumb/breadcrumb_item.rb
+++ b/lib/ruby_ui/breadcrumb/breadcrumb_item.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module RubyUI
+  class BreadcrumbItem < Base
+    def view_template(&)
+      li(**attrs, &)
+    end
+
+    private
+
+    def default_attrs
+      {
+        class: "inline-flex items-center gap-1.5"
+      }
+    end
+  end
+end

--- a/lib/ruby_ui/breadcrumb/breadcrumb_link.rb
+++ b/lib/ruby_ui/breadcrumb/breadcrumb_link.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module RubyUI
+  class BreadcrumbLink < Base
+    def initialize(href: "#", **attrs)
+      @href = href
+      super(**attrs)
+    end
+
+    def view_template(&)
+      a(href: @href, **attrs, &)
+    end
+
+    private
+
+    def default_attrs
+      {
+        class: "transition-colors hover:text-foreground"
+      }
+    end
+  end
+end

--- a/lib/ruby_ui/breadcrumb/breadcrumb_list.rb
+++ b/lib/ruby_ui/breadcrumb/breadcrumb_list.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module RubyUI
+  class BreadcrumbList < Base
+    def view_template(&)
+      ol(**attrs, &)
+    end
+
+    private
+
+    def default_attrs
+      {
+        class: "flex flex-wrap items-center gap-1.5 break-words text-sm text-muted-foreground sm:gap-2.5"
+      }
+    end
+  end
+end

--- a/lib/ruby_ui/breadcrumb/breadcrumb_page.rb
+++ b/lib/ruby_ui/breadcrumb/breadcrumb_page.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module RubyUI
+  class BreadcrumbPage < Base
+    def view_template(&)
+      span(**attrs, &)
+    end
+
+    private
+
+    def default_attrs
+      {
+        aria: {disabled: true, current: "page"},
+        class: "font-normal text-foreground",
+        role: "link"
+      }
+    end
+  end
+end

--- a/lib/ruby_ui/breadcrumb/breadcrumb_separator.rb
+++ b/lib/ruby_ui/breadcrumb/breadcrumb_separator.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module RubyUI
+  class BreadcrumbSeparator < Base
+    def view_template(&block)
+      li(**attrs) do
+        if block
+          block.call
+        else
+          icon
+        end
+      end
+    end
+
+    private
+
+    def icon
+      svg(
+        xmlns: "http://www.w3.org/2000/svg",
+        class: "w-4 h-4",
+        viewbox: "0 0 24 24",
+        fill: "none",
+        stroke: "currentColor",
+        stroke_width: "2",
+        stroke_linecap: "round",
+        stroke_linejoin: "round"
+      ) { |s| s.path(d: "m9 18 6-6-6-6") }
+    end
+
+    def default_attrs
+      {
+        aria: {hidden: true},
+        class: "[&>svg]:w-3.5 [&>svg]:h-3.5",
+        role: "presentation"
+      }
+    end
+  end
+end

--- a/test/ruby_ui/breadcrumb_test.rb
+++ b/test/ruby_ui/breadcrumb_test.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class RubyUI::BreadcrumbTest < ComponentTest
+  def test_render_with_all_items
+    output = phlex do
+      RubyUI.Breadcrumb do
+        RubyUI.BreadcrumbList do
+          RubyUI.BreadcrumbItem do
+            RubyUI.BreadcrumbLink(href: "#") { "Home" }
+          end
+          RubyUI.BreadcrumbSeparator()
+          RubyUI.BreadcrumbItem do
+            RubyUI.BreadcrumbLink(href: "/docs/accordion") { "Components" }
+          end
+          RubyUI.BreadcrumbSeparator()
+          RubyUI.BreadcrumbItem do
+            RubyUI.BreadcrumbPage { "Breadcrumb" }
+          end
+        end
+      end
+    end
+
+    assert_match(/Components/, output)
+  end
+end


### PR DESCRIPTION
I implemented the Breadcrumb component based on the [shadcn/ui](https://ui.shadcn.com/docs/components/breadcrumb) lib. The component is composed of several child parts:

- BreadcrumbEllipsis
- BreadcrumbItem
- BreadcrumbLink
- BreadcrumbList
- BreadcrumbPage
- BreadcrumbSeparator

The icons were sourced from the [lucide](https://github.com/lucide-icons/lucide) repo.

I added the component documentation in ruby-ui/web, including a few usage examples:

<img width="769" alt="Captura de Tela 2024-11-24 às 09 11 48" src="https://github.com/user-attachments/assets/0b962c97-5eed-451e-91d5-f7e9e3f5aa0d">
