### PR TITLE
Fix `rails g ruby_ui:component` generator

### DIFF
--- a/ruby_ui.gemspec
+++ b/ruby_ui.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.description = "Ruby UI is a UI Component Library for Ruby developers. Built on top of the Phlex Framework."
   s.authors = ["George Kettle"]
   s.email = "george.kettle@icloud.com"
-  s.files = Dir["lib/**/*.rb", "tasks/**/*.rake"]
+  s.files = Dir["lib/**/*.{rb,yml}", "tasks/**/*.rake"]
   s.require_path = "lib"
   s.homepage =
     "https://rubygems.org/gems/ruby_ui"


### PR DESCRIPTION
The `dependencies.yml` file that contains some info about component dependencies isn't being included in RubyUI gem files on release, because of this, some components could not be generated correctly.