### PR TITLE
Fix alert dialog width and height

### DIFF
--- a/lib/ruby_ui/alert_dialog/alert_dialog_content.rb
+++ b/lib/ruby_ui/alert_dialog/alert_dialog_content.rb
@@ -26,7 +26,7 @@ module RubyUI
       div(
         role: "alertdialog",
         data_state: "open",
-        class: "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg md:w-full",
+        class: "flex flex-col fixed left-[50%] top-[50%] z-50 w-full max-w-lg max-h-screen overflow-y-auto translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg md:w-full",
         style: "pointer-events:auto",
         &
       )


### PR DESCRIPTION
We here at Linkana faced some issues with AlertDialog when using it in some contexts. We fixed it and now we are sending the fixes here back to RubyUI.

### Before:
https://play.tailwindcss.com/2gBTDI20Xu

### After: 
https://play.tailwindcss.com/37DZTDaurU