### PR TITLE
Add Progress component

### DIFF
--- a/lib/ruby_ui/progress/progress.rb
+++ b/lib/ruby_ui/progress/progress.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module RubyUI
+  class Progress < Base
+    def initialize(value: 0, **attrs)
+      @value = value.to_f.clamp(0, 100)
+
+      super(**attrs)
+    end
+
+    def view_template
+      div(**attrs) do
+        div(**indicator_attrs)
+      end
+    end
+
+    private
+
+    def default_attrs
+      {
+        role: "progressbar",
+        aria_valuenow: @value,
+        aria_valuemin: 0,
+        aria_valuemax: 100,
+        aria_valuetext: "#{@value}%",
+        class: "relative h-2 overflow-hidden rounded-full bg-primary/20 [&>*]:bg-primary"
+      }
+    end
+
+    def indicator_attrs
+      {
+        class: "h-full w-full flex-1",
+        style: "transform: translateX(-#{100 - @value}%)"
+      }
+    end
+  end
+end

--- a/test/ruby_ui/progress_test.rb
+++ b/test/ruby_ui/progress_test.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class RubyUI::ProgressTest < ComponentTest
+  def test_render
+    output = phlex do
+      RubyUI::Progress(value: 50)
+    end
+
+    assert_match(/aria-valuemin="0"/, output)
+    assert_match(/aria-valuemax="100"/, output)
+    assert_match(/aria-valuenow="50.0"/, output)
+    assert_match(/aria-valuetext="50.0%"/, output)
+    assert_match(/translateX\(-50.0%\)/, output)
+  end
+end


### PR DESCRIPTION
This PR adds a Progress component based on the [shadcn/ui component](https://ui.shadcn.com/docs/components/progress):

Doc examples:
![image](https://github.com/user-attachments/assets/5219a9ef-a5f2-4536-b8bd-3d3afd08f4ac)
![image](https://github.com/user-attachments/assets/41cc1d4f-ab2c-4369-a083-115e8675461a)

I'll also add the component to the docs in another [PR](https://github.com/ruby-ui/web/pull/158).
