### PR TITLE
[FIX] `FormFieldError` obligation

### DIFF
--- a/lib/ruby_ui/form/form_field_controller.js
+++ b/lib/ruby_ui/form/form_field_controller.js
@@ -5,10 +5,12 @@ export default class extends Controller {
   static values = { shouldValidate: false };
 
   connect() {
-    if (this.errorTarget.textContent) {
-      this.shouldValidateValue = true;
-    } else {
-      this.errorTarget.classList.add("hidden");
+    if (this.hasErrorTarget) {
+      if (this.errorTarget.textContent) {
+        this.shouldValidateValue = true;
+      } else {
+        this.errorTarget.classList.add("hidden");
+      }
     }
   }
 


### PR DESCRIPTION
- When `FormFieldError` is not added on `FormField` component a JS error is raised on the browser console.
- This fix removes the obligation to add `FormFieldError` on `FormField`