### PR TITLE
Add toggle all checkbox to combobox

### DIFF
--- a/lib/ruby_ui/combobox/combobox_controller.js
+++ b/lib/ruby_ui/combobox/combobox_controller.js
@@ -9,6 +9,7 @@ export default class extends Controller {
 
   static targets = [
     "input",
+    "toggle",
     "popover",
     "item",
     "emptyState",
@@ -37,6 +38,12 @@ export default class extends Controller {
 
   inputContent(input) {
     return input.dataset.text || input.parentElement.innerText
+  }
+
+  toggleInputs() {
+    const isChecked = this.toggleTarget.checked
+    this.inputTargets.forEach(input => input.checked = isChecked)
+    this.updateTriggerContent()
   }
 
   updateTriggerContent() {

--- a/lib/ruby_ui/combobox/combobox_controller.js
+++ b/lib/ruby_ui/combobox/combobox_controller.js
@@ -35,8 +35,9 @@ export default class extends Controller {
       this.closePopover()
     }
 
-    const isToggleAllUnchecked = this.hasToggleAllTarget && !e.target.checked
-    if (isToggleAllUnchecked) this.toggleAllTarget.checked = false
+    if (this.hasToggleAllTarget && !e.target.checked) {
+      this.toggleAllTarget.checked = false
+    }
   }
 
   inputContent(input) {

--- a/lib/ruby_ui/combobox/combobox_controller.js
+++ b/lib/ruby_ui/combobox/combobox_controller.js
@@ -84,6 +84,12 @@ export default class extends Controller {
     }
 
     const filterTerm = this.searchInputTarget.value.toLowerCase()
+
+    if (this.hasToggleAllTarget) {
+      if (filterTerm) this.toggleAllTarget.parentElement.classList.add("hidden")
+      else this.toggleAllTarget.parentElement.classList.remove("hidden")
+    }
+
     let resultCount = 0
 
     this.selectedItemIndex = null

--- a/lib/ruby_ui/combobox/combobox_controller.js
+++ b/lib/ruby_ui/combobox/combobox_controller.js
@@ -9,7 +9,7 @@ export default class extends Controller {
 
   static targets = [
     "input",
-    "toggle",
+    "toggleAll",
     "popover",
     "item",
     "emptyState",
@@ -34,14 +34,17 @@ export default class extends Controller {
     if (e.target.type == "radio") {
       this.closePopover()
     }
+
+    const isToggleAllUnchecked = this.hasToggleAllTarget && !e.target.checked
+    if (isToggleAllUnchecked) this.toggleAllTarget.checked = false
   }
 
   inputContent(input) {
     return input.dataset.text || input.parentElement.innerText
   }
 
-  toggleInputs() {
-    const isChecked = this.toggleTarget.checked
+  toggleAllItems() {
+    const isChecked = this.toggleAllTarget.checked
     this.inputTargets.forEach(input => input.checked = isChecked)
     this.updateTriggerContent()
   }

--- a/lib/ruby_ui/combobox/combobox_toggle_all_checkbox.rb
+++ b/lib/ruby_ui/combobox/combobox_toggle_all_checkbox.rb
@@ -3,16 +3,21 @@
 module RubyUI
   class ComboboxToggleAllCheckbox < Base
     def view_template
-      render RubyUI::ComboboxCheckbox.new(**attrs)
+      input(type: "checkbox", **attrs)
     end
 
     private
 
     def default_attrs
       {
+        class: [
+          "peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background accent-primary",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+          "disabled:cursor-not-allowed disabled:opacity-50"
+        ],
         data: {
-          ruby_ui__combobox_target: "toggle",
-          action: "change->ruby-ui--combobox#toggleInputs"
+          ruby_ui__combobox_target: "toggleAll",
+          action: "change->ruby-ui--combobox#toggleAllItems"
         }
       }
     end

--- a/lib/ruby_ui/combobox/combobox_toggle_all_checkbox.rb
+++ b/lib/ruby_ui/combobox/combobox_toggle_all_checkbox.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module RubyUI
+  class ComboboxToggleAllCheckbox < Base
+    def view_template
+      render RubyUI::ComboboxCheckbox.new(**attrs)
+    end
+
+    private
+
+    def default_attrs
+      {
+        data: {
+          ruby_ui__combobox_target: "toggle",
+          action: "change->ruby-ui--combobox#toggleInputs"
+        }
+      }
+    end
+  end
+end


### PR DESCRIPTION
Added a toggle target to the combobox's Stimulus controller, enabling the selection and deselection of all checkboxes. To enhance usability, I introduced a new component, `ComboboxToggleAllCheckbox`, which encapsulates the controller settings.

Here's a short demo:

https://github.com/user-attachments/assets/226bf91d-c89b-420f-8c97-4cca2d40eeb0



