### PR TITLE
Upgrade phlex to 2.0.2 version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,7 +16,7 @@ GEM
     parser (3.3.6.0)
       ast (~> 2.4.1)
       racc
-    phlex (2.0.0.beta2)
+    phlex (2.0.2)
     racc (1.8.1)
     rainbow (3.1.1)
     rake (13.2.1)
@@ -60,7 +60,7 @@ PLATFORMS
 
 DEPENDENCIES
   minitest (~> 5.0)
-  phlex (>= 2.0.0.beta2)
+  phlex (>= 2.0.2)
   rake (~> 13.0)
   rouge (~> 4.2.0)
   ruby_ui!

--- a/ruby_ui.gemspec
+++ b/ruby_ui.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 3.3.1"
 
-  s.add_development_dependency "phlex", ">= 2.0.0.beta2"
+  s.add_development_dependency "phlex", ">= 2.0.2"
   s.add_development_dependency "rouge", "~> 4.2.0"
   s.add_development_dependency "tailwind_merge", "~> 0.12"
   s.add_development_dependency "rake", "~> 13.0"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -19,14 +19,12 @@ end
 
 class ComponentTest < Minitest::Test
   def render(component, &)
-    component.call(view_context:, &)
+    component.call(&)
   end
 
   def phlex(&)
     render Phlex::HTML.new, &
   end
-
-  def view_context = nil
 end
 
 # this is a tracepoint that will output the path of all files loaded that contain the string "phlex"


### PR DESCRIPTION
I upgraded the Phlex gem to version 2.0.2, but during the process, the tests started failing with the following error:

> ArgumentError: unknown keyword: :view_context
> /Users/karinevieira/.asdf/installs/ruby/3.3.5/lib/ruby/gems/3.3.0/gems/phlex-2.0.2/lib/phlex/sgml.rb:46:in `call'
>     test/test_helper.rb:22:in `render'
>     test/test_helper.rb:26:in `phlex'

After investigating the codebase, I found that support for nil values seems to have been [removed](https://github.com/phlex-ruby/phlex-rails/pull/258/files#diff-7021946ec728081c8d64ef27d605db4c8ff78a205d6bcb5a5bc0fd3a828acee6).

Additionally, according to the [docs](https://www.phlex.fun/components/testing.html#testing), `view_context` is only required in the context of Rails applications, which is not our case. Given that, I removed it.

After making this change, the tests started passing again, but I’m not entirely sure if this is the best approach. Any thoughts?