### PR TITLE
Fix display of combobox items

### DIFF
--- a/lib/ruby_ui/combobox/combobox_item.rb
+++ b/lib/ruby_ui/combobox/combobox_item.rb
@@ -11,7 +11,7 @@ module RubyUI
     def default_attrs
       {
         class: [
-          "flex flex-row w-full text-wrap truncate gap-2 items-center rounded-sm px-2 py-1.5 text-sm outline-none cursor-pointer",
+          "flex flex-row w-full text-wrap [&>span,&>div]:truncate gap-2 items-center rounded-sm px-2 py-1 text-sm outline-none cursor-pointer",
           "select-none has-[:checked]:bg-accent hover:bg-accent p-2",
           "[&>svg]:pointer-events-none [&>svg]:size-4 [&>svg]:shrink-0 aria-[current=true]:bg-accent aria-[current=true]:ring aria-[current=true]:ring-offset-2"
         ],


### PR DESCRIPTION
The truncate on the combobox item was causing issues, making it not have the proper height, and this also affects the ToggleAll.

**Before**
<img height="400px" src="https://github.com/user-attachments/assets/1163e0c0-c544-45bd-862d-635d87d400db" alt="image">

**After**
<img height="400px" src="https://github.com/user-attachments/assets/0e1fb526-933f-44b3-bc01-f8c703280a49" alt="image">

**ToggleAll**
<img width="400px" src="https://github.com/user-attachments/assets/6253e8aa-15b8-4729-844a-79d825df7648" alt="image">
