### PR TITLE
Readme: update speed comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,13 +63,13 @@ Visit https://rubyui.com/docs/introduction to view the full documentation, inclu
 
 ## Speed Comparison 🏎️
 
-RubyUI, powered by Phlex, outperforms traditional methods:
+RubyUI, powered by Phlex, outperforms alternative methods:
 
 - Phlex: Baseline 🏁
-- ViewComponent: 5.57x slower 🐢
-- ERB Templates: 12.08x slower 🐌
+- ViewComponent: ~1.5x slower 🚙
+- ERB Templates: ~5x slower 🐢
 
-_Huge thanks to @KonnorRogers for running these tests_ 🙏
+See the original [view layers benchmark](https://github.com/KonnorRogers/view-layer-benchmarks) by @KonnorRogers and its [variations](https://github.com/KonnorRogers/view-layer-benchmarks/forks).
 
 ## Importmap notes:
 


### PR DESCRIPTION
First of all, thanks for bringing a new life to PhlexUI (I've been using a custom fork for a while; now there is a hope that I can switch to the new upstream some day 🙂).

I've been checking the repo recently and found that the speed comparison is out of tune. Phlex is fast but the difference is not that big (compared to the primary competitor—View Component).

I've updated the numbers to reflect the latest results from the Konnor's repo as well as [my modification of it](https://github.com/palkan/view-layer-benchmarks/tree/table-component) (I tried to test against a real-world example—and that's a PhlexUI Table component, btw).