### PR TITLE
Add a separator component

### DIFF
--- a/lib/ruby_ui/separator/separator.rb
+++ b/lib/ruby_ui/separator/separator.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module RubyUI
+  class Separator < Base
+    ORIENTATIONS = %i[horizontal vertical].freeze
+
+    def initialize(as: "div", orientation: :horizontal, decorative: true, **attrs)
+      raise ArgumentError, "Invalid orientation: #{orientation}" unless ORIENTATIONS.include?(orientation.to_sym)
+
+      @as = as
+      @orientation = orientation.to_sym
+      @decorative = decorative
+      super(**attrs)
+    end
+
+    def view_template(&)
+      public_send(@as, **attrs, &)
+    end
+
+    private
+
+    def default_attrs
+      {
+        role: (@decorative ? "none" : "separator"),
+        class: [
+          "shrink-0 bg-border",
+          orientation_classes
+        ],
+        data: {
+          orientation: @orientation
+        }
+      }
+    end
+
+    def orientation_classes
+      return "h-[1px] w-full" if @orientation == :horizontal
+
+      "h-full w-[1px]"
+    end
+  end
+end

--- a/lib/ruby_ui/separator/separator.rb
+++ b/lib/ruby_ui/separator/separator.rb
@@ -4,17 +4,17 @@ module RubyUI
   class Separator < Base
     ORIENTATIONS = %i[horizontal vertical].freeze
 
-    def initialize(as: "div", orientation: :horizontal, decorative: true, **attrs)
+    def initialize(as: :div, orientation: :horizontal, decorative: true, **attrs)
       raise ArgumentError, "Invalid orientation: #{orientation}" unless ORIENTATIONS.include?(orientation.to_sym)
 
-      @as = as
+      @as = as.to_sym
       @orientation = orientation.to_sym
       @decorative = decorative
       super(**attrs)
     end
 
     def view_template(&)
-      public_send(@as, **attrs, &)
+      tag(@as, **attrs, &)
     end
 
     private
@@ -25,10 +25,7 @@ module RubyUI
         class: [
           "shrink-0 bg-border",
           orientation_classes
-        ],
-        data: {
-          orientation: @orientation
-        }
+        ]
       }
     end
 

--- a/test/ruby_ui/separator_test.rb
+++ b/test/ruby_ui/separator_test.rb
@@ -10,7 +10,7 @@ class RubyUI::SeparatorTest < ComponentTest
 
     assert_match(/div/, output)
     assert_match(/role="none"/, output)
-    assert_match(/data-orientation="horizontal"/, output)
+    assert_match(/h-\[1px\]/, output)
   end
 
   def test_render_with_vertical_orientation
@@ -18,7 +18,7 @@ class RubyUI::SeparatorTest < ComponentTest
       RubyUI.Separator(orientation: :vertical)
     end
 
-    assert_match(/data-orientation="vertical"/, output)
+    assert_match(/w-\[1px\]/, output)
   end
 
   def test_render_with_decorative_false
@@ -34,6 +34,6 @@ class RubyUI::SeparatorTest < ComponentTest
       RubyUI.Separator(as: "hr")
     end
 
-    assert_match(/hr/, output)
+    assert_match(/<hr/, output)
   end
 end

--- a/test/ruby_ui/separator_test.rb
+++ b/test/ruby_ui/separator_test.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class RubyUI::SeparatorTest < ComponentTest
+  def test_render
+    output = phlex do
+      RubyUI.Separator()
+    end
+
+    assert_match(/div/, output)
+    assert_match(/role="none"/, output)
+    assert_match(/data-orientation="horizontal"/, output)
+  end
+
+  def test_render_with_vertical_orientation
+    output = phlex do
+      RubyUI.Separator(orientation: :vertical)
+    end
+
+    assert_match(/data-orientation="vertical"/, output)
+  end
+
+  def test_render_with_decorative_false
+    output = phlex do
+      RubyUI.Separator(decorative: false)
+    end
+
+    assert_match(/role="separator"/, output)
+  end
+
+  def test_render_with_custom_tag
+    output = phlex do
+      RubyUI.Separator(as: "hr")
+    end
+
+    assert_match(/hr/, output)
+  end
+end


### PR DESCRIPTION
This PR adds a separator component based on the [shadcn/ui separator](https://ui.shadcn.com/docs/components/separator).  

- The component supports two orientations: `horizontal | vertical`.
- The root element can be customized using the `as` parameter
- The element role can be set as `separator` using the `decorative` parameter

**Doc:**
![image](https://github.com/user-attachments/assets/e8d4348e-07ba-47a3-94d6-9781787f2ebd)
