### PR TITLE
Include erb files in the gem so install works

### DIFF
--- a/ruby_ui.gemspec
+++ b/ruby_ui.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.description = "Ruby UI is a UI Component Library for Ruby developers. Built on top of the Phlex Framework."
   s.authors = ["George Kettle"]
   s.email = "george.kettle@icloud.com"
-  s.files = Dir["lib/**/*.{rb,yml}", "tasks/**/*.rake"]
+  s.files = Dir["lib/**/*.{rb,yml,erb}", "tasks/**/*.rake"]
   s.require_path = "lib"
   s.homepage =
     "https://rubygems.org/gems/ruby_ui"


### PR DESCRIPTION
As mentioned in [this comment](https://github.com/ruby-ui/ruby_ui/issues/226#issuecomment-2744708608), the installer looks for an erb file and it can't find it because the packaged gem doesn't include it. This simply adds `.erb` files to what's included in the gemspec.

I tried pointing my gem file at this branch and running `rails g ruby_ui:install` and it managed to complete the install (though it complained about `tailwind.config.js` not being available, since Tailwind 4 no longer uses that file by default). I used #232 to get the tailwind css config. I haven't tested that part thoroughly but it seems promising so far