### PR TITLE
Upgrade phlex to 2.1.2 version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,7 +16,7 @@ GEM
     parser (3.3.6.0)
       ast (~> 2.4.1)
       racc
-    phlex (2.0.2)
+    phlex (2.1.2)
     racc (1.8.1)
     rainbow (3.1.1)
     rake (13.2.1)
@@ -60,7 +60,7 @@ PLATFORMS
 
 DEPENDENCIES
   minitest (~> 5.0)
-  phlex (>= 2.0.2)
+  phlex (>= 2.1.2)
   rake (~> 13.0)
   rouge (~> 4.2.0)
   ruby_ui!

--- a/ruby_ui.gemspec
+++ b/ruby_ui.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 3.3.1"
 
-  s.add_development_dependency "phlex", ">= 2.0.2"
+  s.add_development_dependency "phlex", ">= 2.1.2"
   s.add_development_dependency "rouge", "~> 4.2.0"
   s.add_development_dependency "tailwind_merge", "~> 0.12"
   s.add_development_dependency "rake", "~> 13.0"


### PR DESCRIPTION
This PR bumps the `phlex` gem to the lastest version (2.1.2).