### PR TITLE
Fix container settings

### DIFF
--- a/lib/generators/ruby_ui/install/templates/tailwind.css.erb
+++ b/lib/generators/ruby_ui/install/templates/tailwind.css.erb
@@ -51,11 +51,6 @@
   --warning-foreground: hsl(0 0% 100%);
   --success: hsl(87 100% 37%);
   --success-foreground: hsl(0 0% 100%);
-
-  /* Container settings */
-  --container-center: true;
-  --container-padding: hsl(2rem);
-  --container-max-width-2xl: hsl(1400px);
 }
 
 .dark {
@@ -142,6 +137,13 @@
   --color-warning-foreground: var(--warning-foreground);
   --color-success: var(--success);
   --color-success-foreground: var(--success-foreground);
+}
+
+/* Container settings */
+@utility container {
+  margin-inline: auto;
+  padding-inline: 2rem;
+  max-width: 1400px;
 }
 
 @layer base {


### PR DESCRIPTION
The previous container css variables weren't working. Now Tailwind V4 allows configuring container via `@utility` directive. Docs: https://tailwindcss.com/docs/upgrade-guide#container-configuration 