### PR TITLE
Remove string interpolation from generated ruby ui config

### DIFF
--- a/lib/generators/ruby_ui/install/templates/ruby_ui.rb.erb
+++ b/lib/generators/ruby_ui/install/templates/ruby_ui.rb.erb
@@ -11,7 +11,7 @@ Rails.autoloaders.main.inflector.inflect(
 
 # Allow using RubyUI::ComponentName instead Components::RubyUI::ComponentName
 Rails.autoloaders.main.push_dir(
-  "#{Rails.root}/app/components/ruby_ui", namespace: RubyUI
+  Rails.root.join("app/components/ruby_ui"), namespace: RubyUI
 )
 
 # Allow using RubyUI::ComponentName instead RubyUI::ComponentName::ComponentName


### PR DESCRIPTION
To please linters (standard-rails/rubocop-rails)