### PR TITLE
Remove relative from table component

### DIFF
--- a/lib/ruby_ui/table/table.rb
+++ b/lib/ruby_ui/table/table.rb
@@ -3,7 +3,7 @@
 module RubyUI
   class Table < Base
     def view_template(&block)
-      div(class: "relative w-full overflow-auto") do
+      div(class: "w-full overflow-auto") do
         table(**attrs, &block)
       end
     end


### PR DESCRIPTION
I'm not sure if this relative is necessary, but I removed in my app and it's working fine. Using `relative` messes with z ordering even with dropdown is on a higher z index:

Before
<img width="307" alt="Screenshot 2025-03-26 at 10 19 05" src="https://github.com/user-attachments/assets/21dacef4-16f8-4050-8749-e6ee7cbe924b" />

After:
<img width="396" alt="Screenshot 2025-03-26 at 10 21 24" src="https://github.com/user-attachments/assets/77e5e794-f67d-4463-a1ef-663db13790a9" />
