### PR TITLE
Restrict separator `as` type

### DIFF
--- a/lib/ruby_ui/separator/separator.rb
+++ b/lib/ruby_ui/separator/separator.rb
@@ -7,7 +7,7 @@ module RubyUI
     def initialize(as: :div, orientation: :horizontal, decorative: true, **attrs)
       raise ArgumentError, "Invalid orientation: #{orientation}" unless ORIENTATIONS.include?(orientation.to_sym)
 
-      @as = as.to_sym
+      @as = as
       @orientation = orientation.to_sym
       @decorative = decorative
       super(**attrs)

--- a/test/ruby_ui/separator_test.rb
+++ b/test/ruby_ui/separator_test.rb
@@ -31,7 +31,7 @@ class RubyUI::SeparatorTest < ComponentTest
 
   def test_render_with_custom_tag
     output = phlex do
-      RubyUI.Separator(as: "hr")
+      RubyUI.Separator(as: :hr)
     end
 
     assert_match(/<hr/, output)


### PR DESCRIPTION
I think we should follow Phlex restrictions allowing only symbols for `tag` method.