### PR TITLE
Relax ruby version

### DIFF
--- a/ruby_ui.gemspec
+++ b/ruby_ui.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
     "https://rubygems.org/gems/ruby_ui"
   s.license = "MIT"
 
-  s.required_ruby_version = ">= 3.3.1"
+  s.required_ruby_version = ">= 3.2"
 
   s.add_development_dependency "phlex", ">= 2.1.2"
   s.add_development_dependency "rouge", "~> 4.2.0"


### PR DESCRIPTION
Phlex required Ruby >= 3.3.1 when it was on beta/rc, after Phlex 2.0 release now it requires Ruby > 3.2.