### PR TITLE
Remove tailwind forms and typography dependencies

### DIFF
--- a/lib/generators/ruby_ui/install/install_generator.rb
+++ b/lib/generators/ruby_ui/install/install_generator.rb
@@ -62,12 +62,6 @@ module RubyUI
       def install_tailwind_plugins
         say "Installing tw-animate-css plugin"
         install_js_package("tw-animate-css")
-
-        say "Installing @tailwindcss/forms plugin"
-        install_js_package("@tailwindcss/forms")
-
-        say "Installing @tailwindcss/typography plugin"
-        install_js_package("@tailwindcss/typography")
       end
 
       def add_ruby_ui_base

--- a/lib/generators/ruby_ui/install/templates/tailwind.css.erb
+++ b/lib/generators/ruby_ui/install/templates/tailwind.css.erb
@@ -1,8 +1,5 @@
 @import "tailwindcss";
 
-@plugin "@tailwindcss/forms";
-@plugin "@tailwindcss/typography";
-
 <% if using_importmap? %>
 @import "../../../vendor/javascript/tw-animate-css.js";
 <% else %>


### PR DESCRIPTION
Remove tailwind forms and typography from RubyUI installation.
Run on a Rails 8 new project, and it did not fetch tailwind/forms, tailwind/typography or its dependences

<img width="1074" alt="image" src="https://github.com/user-attachments/assets/ae78b8cb-8e12-4fdf-9de7-67034deeec0c" />


