### PR TITLE
fix: use tailwind 4.x bg clases with modifiers

### DIFF
--- a/lib/ruby_ui/table/table_footer.rb
+++ b/lib/ruby_ui/table/table_footer.rb
@@ -10,7 +10,7 @@ module RubyUI
 
     def default_attrs
       {
-        class: "border-t bg-muted bg-opacity-50 font-medium[& amp;>tr]:last:border-b-0"
+        class: "border-t bg-muted/50 font-medium[& amp;>tr]:last:border-b-0"
       }
     end
   end

--- a/lib/ruby_ui/table/table_row.rb
+++ b/lib/ruby_ui/table/table_row.rb
@@ -10,7 +10,7 @@ module RubyUI
 
     def default_attrs
       {
-        class: "border-b transition-colors hover:bg-muted hover:bg-opacity-50 data-[state=selected]:bg-muted"
+        class: "border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted"
       }
     end
   end


### PR DESCRIPTION
In adopting Ruby UI I noticed that the Table component class names were not being merged correctly, which broke the hover effect.

- `bg-opacity` utilities are [removed](https://tailwindcss.com/docs/upgrade-guide#removed-deprecated-utilities) in Tailwind 4
- As such recent versions of `tailwind_merge` no longer supports them:
```
[8] pry(main)> merger = TailwindMerge::Merger.new
[7] pry(main)> merger.merge("border-b transition-colors hover:bg-muted hover:bg-opacity-50 data-[state=selected]:bg-muted")
=> "border-b transition-colors hover:bg-opacity-50 data-[state=selected]:bg-muted"
```

For RubyUI, recent versions of Tailwind and `tailwind_merge` are installed or recommended by default.

I noticed that the docs for RubyUI get around this by using a [version of tailwind merge](https://github.com/ruby-ui/web/blob/main/Gemfile#L82) that has tailwind 3.x semantics, but I think it would be best to use Tailwind 4 semantics/utilities.