### PR TITLE
aria-disabled for Combobox

### DIFF
--- a/lib/ruby_ui/combobox/combobox_checkbox.rb
+++ b/lib/ruby_ui/combobox/combobox_checkbox.rb
@@ -13,7 +13,8 @@ module RubyUI
         class: [
           "peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background accent-primary",
           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
-          "disabled:cursor-not-allowed disabled:opacity-50"
+          "disabled:cursor-not-allowed disabled:opacity-50",
+          "aria-disabled:cursor-not-allowed aria-disabled:opacity-50 aria-disabled:pointer-events-none"
         ],
         data: {
           ruby_ui__combobox_target: "input",

--- a/lib/ruby_ui/combobox/combobox_radio.rb
+++ b/lib/ruby_ui/combobox/combobox_radio.rb
@@ -10,7 +10,13 @@ module RubyUI
 
     def default_attrs
       {
-        class: "aspect-square h-4 w-4 rounded-full border border-primary accent-primary text-primary shadow focus:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+        class: [
+          "aspect-square h-4 w-4 rounded-full border border-primary accent-primary text-primary shadow",
+          "focus:outline-none",
+          "focus-visible:ring-1 focus-visible:ring-ring",
+          "disabled:cursor-not-allowed disabled:opacity-50",
+          "aria-disabled:cursor-not-allowed aria-disabled:opacity-50 aria-disabled:pointer-events-none"
+        ],
         data: {
           ruby_ui__combobox_target: "input",
           ruby_ui__form_field_target: "input",

--- a/lib/ruby_ui/combobox/combobox_search_input.rb
+++ b/lib/ruby_ui/combobox/combobox_search_input.rb
@@ -19,16 +19,22 @@ module RubyUI
     def default_attrs
       {
         type: "search",
-        class: "flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-none border-none focus:ring-0 placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
         role: "searchbox",
+        autocorrect: "off",
+        autocomplete: "off",
+        spellcheck: "false",
         placeholder: @placeholder,
+        class: [
+          "flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-none border-none",
+          "focus:ring-0",
+          "placeholder:text-muted-foreground",
+          "disabled:cursor-not-allowed disabled:opacity-50",
+          "aria-disabled:cursor-not-allowed aria-disabled:opacity-50 aria-disabled:pointer-events-none"
+        ],
         data: {
           ruby_ui__combobox_target: "searchInput",
           action: "keyup->ruby-ui--combobox#filterItems search->ruby-ui--combobox#filterItems"
-        },
-        autocomplete: "off",
-        autocorrect: "off",
-        spellcheck: "false"
+        }
       }
     end
 

--- a/lib/ruby_ui/combobox/combobox_toggle_all_checkbox.rb
+++ b/lib/ruby_ui/combobox/combobox_toggle_all_checkbox.rb
@@ -13,7 +13,8 @@ module RubyUI
         class: [
           "peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background accent-primary",
           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
-          "disabled:cursor-not-allowed disabled:opacity-50"
+          "disabled:cursor-not-allowed disabled:opacity-50",
+          "aria-disabled:cursor-not-allowed aria-disabled:opacity-50 aria-disabled:pointer-events-none"
         ],
         data: {
           ruby_ui__combobox_target: "toggleAll",

--- a/lib/ruby_ui/combobox/combobox_trigger.rb
+++ b/lib/ruby_ui/combobox/combobox_trigger.rb
@@ -21,7 +21,13 @@ module RubyUI
     def default_attrs
       {
         type: "button",
-        class: "flex h-full w-full items-center whitespace-nowrap rounded-md text-sm ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-10 px-4 py-2 justify-between",
+        class: [
+          "flex h-full w-full items-center whitespace-nowrap rounded-md text-sm ring-offset-background transition-colors border border-input bg-background h-10 px-4 py-2 justify-between",
+          "hover:bg-accent hover:text-accent-foreground",
+          "disabled:pointer-events-none disabled:opacity-50",
+          "aria-disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:cursor-not-allowed",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+        ],
         data: {
           placeholder: @placeholder,
           ruby_ui__combobox_target: "trigger",


### PR DESCRIPTION
Based on these articles from
[developer.mozilla.org](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-disabled) | [kittygiraudel.com](https://kittygiraudel.com/2024/03/29/on-disabled-and-aria-disabled-attributes) | [dhiwise.com](https://www.dhiwise.com/post/aria-disabled-vs-disabled-when-to-use-each)  | [a11y-101.com](https://a11y-101.com/development/aria-disabled) | [dev.to](https://dev.to/josefine/making-disabled-buttons-more-accessible-21ih)

It's necessary to provide the support for users who want to use `aria-disabled` instead of `disable`