### PR TITLE
aria-disabled for Link

### DIFF
--- a/lib/ruby_ui/link/link.rb
+++ b/lib/ruby_ui/link/link.rb
@@ -2,10 +2,12 @@
 
 module RubyUI
   class Link < Base
-    DISABLED_CLASSES = "disabled:pointer-events-none disabled:opacity-50"
-    FOCUS_VISIBLE_CLASSES = "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-    ARIA_DISABLED_CLASSES = "aria-disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:cursor-not-allowed"
-    DEFAULT_CLASSES = "whitespace-nowrap inline-flex items-center justify-center rounded-md font-medium transition-colors"
+    BASE_CLASSES = [
+      "whitespace-nowrap inline-flex items-center justify-center rounded-md font-medium transition-colors",
+      "disabled:pointer-events-none disabled:opacity-50",
+      "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+      "aria-disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:cursor-not-allowed"
+    ].freeze
 
     def initialize(href: "#", variant: :link, size: :md, icon: false, **attrs)
       @href = href
@@ -41,10 +43,7 @@ module RubyUI
 
     def primary_classes
       [
-        DEFAULT_CLASSES,
-        FOCUS_VISIBLE_CLASSES,
-        DISABLED_CLASSES,
-        ARIA_DISABLED_CLASSES,
+        BASE_CLASSES,
         size_classes,
         "bg-primary text-primary-foreground shadow",
         "hover:bg-primary/90"
@@ -53,10 +52,7 @@ module RubyUI
 
     def link_classes
       [
-        DEFAULT_CLASSES,
-        FOCUS_VISIBLE_CLASSES,
-        DISABLED_CLASSES,
-        ARIA_DISABLED_CLASSES,
+        BASE_CLASSES,
         size_classes,
         "text-primary underline-offset-4",
         "hover:underline"
@@ -65,10 +61,7 @@ module RubyUI
 
     def secondary_classes
       [
-        DEFAULT_CLASSES,
-        FOCUS_VISIBLE_CLASSES,
-        DISABLED_CLASSES,
-        ARIA_DISABLED_CLASSES,
+        BASE_CLASSES,
         size_classes,
         "bg-secondary text-secondary-foreground",
         "hover:bg-opacity-80"
@@ -77,10 +70,7 @@ module RubyUI
 
     def destructive_classes
       [
-        DEFAULT_CLASSES,
-        FOCUS_VISIBLE_CLASSES,
-        DISABLED_CLASSES,
-        ARIA_DISABLED_CLASSES,
+        BASE_CLASSES,
         size_classes,
         "bg-destructive text-destructive-foreground shadow-sm",
         "hover:bg-destructive/90"
@@ -89,10 +79,7 @@ module RubyUI
 
     def outline_classes
       [
-        DEFAULT_CLASSES,
-        FOCUS_VISIBLE_CLASSES,
-        DISABLED_CLASSES,
-        ARIA_DISABLED_CLASSES,
+        BASE_CLASSES,
         size_classes,
         "border border-input bg-background shadow-sm",
         "hover:bg-accent hover:text-accent-foreground"
@@ -101,10 +88,7 @@ module RubyUI
 
     def ghost_classes
       [
-        DEFAULT_CLASSES,
-        FOCUS_VISIBLE_CLASSES,
-        DISABLED_CLASSES,
-        ARIA_DISABLED_CLASSES,
+        BASE_CLASSES,
         size_classes,
         "hover:bg-accent hover:text-accent-foreground"
       ]

--- a/lib/ruby_ui/link/link.rb
+++ b/lib/ruby_ui/link/link.rb
@@ -2,6 +2,11 @@
 
 module RubyUI
   class Link < Base
+    DISABLED_CLASSES = "disabled:pointer-events-none disabled:opacity-50"
+    FOCUS_VISIBLE_CLASSES = "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+    ARIA_DISABLED_CLASSES = "aria-disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:cursor-not-allowed"
+    DEFAULT_CLASSES = "whitespace-nowrap inline-flex items-center justify-center rounded-md font-medium transition-colors"
+
     def initialize(href: "#", variant: :link, size: :md, icon: false, **attrs)
       @href = href
       @variant = variant.to_sym
@@ -36,43 +41,72 @@ module RubyUI
 
     def primary_classes
       [
-        "whitespace-nowrap inline-flex items-center justify-center rounded-md font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 bg-primary text-primary-foreground shadow hover:bg-primary/90",
-        size_classes
+        DEFAULT_CLASSES,
+        FOCUS_VISIBLE_CLASSES,
+        DISABLED_CLASSES,
+        ARIA_DISABLED_CLASSES,
+        size_classes,
+        "bg-primary text-primary-foreground shadow",
+        "hover:bg-primary/90"
       ]
     end
 
     def link_classes
       [
-        "whitespace-nowrap inline-flex items-center justify-center rounded-md font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 text-primary underline-offset-4 hover:underline",
-        size_classes
+        DEFAULT_CLASSES,
+        FOCUS_VISIBLE_CLASSES,
+        DISABLED_CLASSES,
+        ARIA_DISABLED_CLASSES,
+        size_classes,
+        "text-primary underline-offset-4",
+        "hover:underline"
       ]
     end
 
     def secondary_classes
       [
-        "whitespace-nowrap inline-flex items-center justify-center rounded-md font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 bg-secondary text-secondary-foreground hover:bg-opacity-80",
-        size_classes
+        DEFAULT_CLASSES,
+        FOCUS_VISIBLE_CLASSES,
+        DISABLED_CLASSES,
+        ARIA_DISABLED_CLASSES,
+        size_classes,
+        "bg-secondary text-secondary-foreground",
+        "hover:bg-opacity-80"
       ]
     end
 
     def destructive_classes
       [
-        "whitespace-nowrap inline-flex items-center justify-center rounded-md font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90",
-        size_classes
+        DEFAULT_CLASSES,
+        FOCUS_VISIBLE_CLASSES,
+        DISABLED_CLASSES,
+        ARIA_DISABLED_CLASSES,
+        size_classes,
+        "bg-destructive text-destructive-foreground shadow-sm",
+        "hover:bg-destructive/90"
       ]
     end
 
     def outline_classes
       [
-        "whitespace-nowrap inline-flex items-center justify-center rounded-md font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground",
-        size_classes
+        DEFAULT_CLASSES,
+        FOCUS_VISIBLE_CLASSES,
+        DISABLED_CLASSES,
+        ARIA_DISABLED_CLASSES,
+        size_classes,
+        "border border-input bg-background shadow-sm",
+        "hover:bg-accent hover:text-accent-foreground"
       ]
     end
 
     def ghost_classes
       [
-        "whitespace-nowrap inline-flex items-center justify-center rounded-md font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 hover:bg-accent hover:text-accent-foreground",
-        size_classes
+        DEFAULT_CLASSES,
+        FOCUS_VISIBLE_CLASSES,
+        DISABLED_CLASSES,
+        ARIA_DISABLED_CLASSES,
+        size_classes,
+        "hover:bg-accent hover:text-accent-foreground"
       ]
     end
 
@@ -88,10 +122,7 @@ module RubyUI
     end
 
     def default_attrs
-      {
-        type: "button",
-        class: default_classes
-      }
+      {type: "button", class: default_classes}
     end
   end
 end


### PR DESCRIPTION
Based on these articles from
[developer.mozilla.org](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-disabled) | [kittygiraudel.com](https://kittygiraudel.com/2024/03/29/on-disabled-and-aria-disabled-attributes) | [dhiwise.com](https://www.dhiwise.com/post/aria-disabled-vs-disabled-when-to-use-each)  | [a11y-101.com](https://a11y-101.com/development/aria-disabled) | [dev.to](https://dev.to/josefine/making-disabled-buttons-more-accessible-21ih)

It's necessary to provide the support for users who want to use `aria-disabled` instead of `disable`