### PR TITLE
aria-disabled for Radio

### DIFF
--- a/lib/ruby_ui/radio_button/radio_button.rb
+++ b/lib/ruby_ui/radio_button/radio_button.rb
@@ -17,7 +17,8 @@ module RubyUI
         },
         class: [
           "h-4 w-4 p-0 border-primary rounded-full flex-none",
-          "disabled:cursor-not-allowed disabled:opacity-50"
+          "disabled:cursor-not-allowed disabled:opacity-50",
+          "aria-disabled:cursor-not-allowed aria-disabled:opacity-50 aria-disabled:pointer-events-none"
         ]
       }
     end


### PR DESCRIPTION
Based on these articles from
[developer.mozilla.org](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-disabled) | [kittygiraudel.com](https://kittygiraudel.com/2024/03/29/on-disabled-and-aria-disabled-attributes) | [dhiwise.com](https://www.dhiwise.com/post/aria-disabled-vs-disabled-when-to-use-each)  | [a11y-101.com](https://a11y-101.com/development/aria-disabled) | [dev.to](https://dev.to/josefine/making-disabled-buttons-more-accessible-21ih)

It's necessary to provide the support for users who want to use `aria-disabled` instead of `disable`