### PR TITLE
aria-disabled for Select

### DIFF
--- a/lib/ruby_ui/select/select_item.rb
+++ b/lib/ruby_ui/select/select_item.rb
@@ -37,15 +37,24 @@ module RubyUI
       {
         role: "option",
         tabindex: "0",
-        class: "item group relative flex cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground aria-selected:bg-accent aria-selected:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+        data_value: @value,
+        aria_selected: "false",
+        data_orientation: "vertical",
+        class: [
+          "item group relative flex cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors",
+          "focus:bg-accent focus:text-accent-foreground",
+          "hover:bg-accent hover:text-accent-foreground",
+          "disabled:pointer-events-none disabled:opacity-50",
+          "aria-selected:bg-accent aria-selected:text-accent-foreground",
+          "data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+          "aria-disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:cursor-not-allowed"
+        ],
         data: {
           controller: "ruby-ui--select-item",
           action: "click->ruby-ui--select#selectItem keydown.enter->ruby-ui--select#selectItem keydown.down->ruby-ui--select#handleKeyDown keydown.up->ruby-ui--select#handleKeyUp keydown.esc->ruby-ui--select#handleEsc",
           ruby_ui__select_target: "item"
-        },
-        data_value: @value,
-        data_orientation: "vertical",
-        aria_selected: "false"
+        }
+
       }
     end
   end

--- a/lib/ruby_ui/select/select_trigger.rb
+++ b/lib/ruby_ui/select/select_trigger.rb
@@ -33,12 +33,12 @@ module RubyUI
 
     def default_attrs
       {
+        type: "button",
+        role: "combobox",
         data: {
           action: "ruby-ui--select#onClick",
           ruby_ui__select_target: "trigger"
         },
-        type: "button",
-        role: "combobox",
         aria: {
           controls: "radix-:r0:",
           expanded: "false",
@@ -46,8 +46,13 @@ module RubyUI
           haspopup: "listbox",
           activedescendant: true
         },
-        class:
-          "truncate w-full flex h-9 items-center justify-between whitespace-nowrap rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+        class: [
+          "truncate w-full flex h-9 items-center justify-between whitespace-nowrap rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm ring-offset-background",
+          "placeholder:text-muted-foreground",
+          "focus:outline-none focus:ring-1 focus:ring-ring",
+          "disabled:cursor-not-allowed disabled:opacity-50",
+          "aria-disabled:cursor-not-allowed aria-disabled:opacity-50 aria-disabled:pointer-events-none"
+        ]
       }
     end
   end


### PR DESCRIPTION
Based on these articles from
[developer.mozilla.org](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-disabled) | [kittygiraudel.com](https://kittygiraudel.com/2024/03/29/on-disabled-and-aria-disabled-attributes) | [dhiwise.com](https://www.dhiwise.com/post/aria-disabled-vs-disabled-when-to-use-each)  | [a11y-101.com](https://a11y-101.com/development/aria-disabled) | [dev.to](https://dev.to/josefine/making-disabled-buttons-more-accessible-21ih)

It's necessary to provide the support for users who want to use `aria-disabled` instead of `disable`