### PR TITLE
aria-disabled for Tabs

### DIFF
--- a/lib/ruby_ui/tabs/tabs_trigger.rb
+++ b/lib/ruby_ui/tabs/tabs_trigger.rb
@@ -21,7 +21,13 @@ module RubyUI
           action: "click->ruby-ui--tabs#show",
           value: @value
         },
-        class: "inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow"
+        class: [
+          "inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium ring-offset-background transition-all",
+          "disabled:pointer-events-none disabled:opacity-50",
+          "aria-disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:cursor-not-allowed",
+          "data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+        ]
       }
     end
   end


### PR DESCRIPTION
Based on these articles from
[developer.mozilla.org](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-disabled) | [kittygiraudel.com](https://kittygiraudel.com/2024/03/29/on-disabled-and-aria-disabled-attributes) | [dhiwise.com](https://www.dhiwise.com/post/aria-disabled-vs-disabled-when-to-use-each)  | [a11y-101.com](https://a11y-101.com/development/aria-disabled) | [dev.to](https://dev.to/josefine/making-disabled-buttons-more-accessible-21ih)

It's necessary to provide the support for users who want to use `aria-disabled` instead of `disable`