### PR TITLE
aria-disabled for Textarea

### DIFF
--- a/lib/ruby_ui/textarea/textarea.rb
+++ b/lib/ruby_ui/textarea/textarea.rb
@@ -19,7 +19,14 @@ module RubyUI
           ruby_ui__form_field_target: "input",
           action: "input->ruby-ui--form-field#onInput invalid->ruby-ui--form-field#onInvalid"
         },
-        class: "flex w-full rounded-md border bg-background px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:outline-none focus-visible:ring-1 disabled:cursor-not-allowed disabled:opacity-50 border-border focus-visible:ring-ring placeholder:text-muted-foreground"
+        class: [
+          "flex w-full rounded-md border bg-background px-3 py-1 text-sm shadow-sm transition-colors border-border",
+          "placeholder:text-muted-foreground",
+          "disabled:cursor-not-allowed disabled:opacity-50",
+          "file:border-0 file:bg-transparent file:text-sm file:font-medium",
+          "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+          "aria-disabled:cursor-not-allowed aria-disabled:opacity-50 aria-disabled:pointer-events-none"
+        ]
       }
     end
   end


### PR DESCRIPTION
Based on these articles from
[developer.mozilla.org](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-disabled) | [kittygiraudel.com](https://kittygiraudel.com/2024/03/29/on-disabled-and-aria-disabled-attributes) | [dhiwise.com](https://www.dhiwise.com/post/aria-disabled-vs-disabled-when-to-use-each)  | [a11y-101.com](https://a11y-101.com/development/aria-disabled) | [dev.to](https://dev.to/josefine/making-disabled-buttons-more-accessible-21ih)

It's necessary to provide the support for users who want to use `aria-disabled` instead of `disable`