### PR TITLE
aria-disabled for Sheet

### DIFF
--- a/lib/ruby_ui/sheet/sheet_content.rb
+++ b/lib/ruby_ui/sheet/sheet_content.rb
@@ -19,6 +19,7 @@ module RubyUI
       template(data: {ruby_ui__sheet_target: "content"}) do
         div(data: {controller: "ruby-ui--sheet-content"}) do
           backdrop
+
           div(**attrs) do
             block&.call
             close_button
@@ -33,7 +34,9 @@ module RubyUI
       {
         data_state: "open", # For animate in
         class: [
-          "fixed pointer-events-auto z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
+          "fixed pointer-events-auto z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out",
+          "data-[state=open]:animate-in data-[state=open]:duration-500",
+          "data-[state=closed]:animate-out data-[state=closed]:duration-300",
           @side_classes
         ]
       }
@@ -42,8 +45,15 @@ module RubyUI
     def close_button
       button(
         type: "button",
-        class: "absolute end-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground",
-        data_action: "click->ruby-ui--sheet-content#close"
+        data_action: "click->ruby-ui--sheet-content#close",
+        class: [
+          "absolute end-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity",
+          "hover:opacity-100",
+          "disabled:pointer-events-none",
+          "data-[state=open]:bg-accent data-[state=open]:text-muted-foreground",
+          "focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+          "aria-disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:cursor-not-allowed"
+        ]
       ) do
         svg(
           width: "15",
@@ -54,13 +64,13 @@ module RubyUI
           class: "h-4 w-4"
         ) do |s|
           s.path(
-            d:
-                  "M11.7816 4.03157C12.0062 3.80702 12.0062 3.44295 11.7816 3.2184C11.5571 2.99385 11.193 2.99385 10.9685 3.2184L7.50005 6.68682L4.03164 3.2184C3.80708 2.99385 3.44301 2.99385 3.21846 3.2184C2.99391 3.44295 2.99391 3.80702 3.21846 4.03157L6.68688 7.49999L3.21846 10.9684C2.99391 11.193 2.99391 11.557 3.21846 11.7816C3.44301 12.0061 3.80708 12.0061 4.03164 11.7816L7.50005 8.31316L10.9685 11.7816C11.193 12.0061 11.5571 12.0061 11.7816 11.7816C12.0062 11.557 12.0062 11.193 11.7816 10.9684L8.31322 7.49999L11.7816 4.03157Z",
+            d: "M11.7816 4.03157C12.0062 3.80702 12.0062 3.44295 11.7816 3.2184C11.5571 2.99385 11.193 2.99385 10.9685 3.2184L7.50005 6.68682L4.03164 3.2184C3.80708 2.99385 3.44301 2.99385 3.21846 3.2184C2.99391 3.44295 2.99391 3.80702 3.21846 4.03157L6.68688 7.49999L3.21846 10.9684C2.99391 11.193 2.99391 11.557 3.21846 11.7816C3.44301 12.0061 3.80708 12.0061 4.03164 11.7816L7.50005 8.31316L10.9685 11.7816C11.193 12.0061 11.5571 12.0061 11.7816 11.7816C12.0062 11.557 12.0062 11.193 11.7816 10.9684L8.31322 7.49999L11.7816 4.03157Z",
             fill: "currentColor",
             fill_rule: "evenodd",
             clip_rule: "evenodd"
           )
         end
+
         span(class: "sr-only") { "Close" }
       end
     end
@@ -69,8 +79,11 @@ module RubyUI
       div(
         data_state: "open",
         data_action: "click->ruby-ui--sheet-content#close",
-        class:
-              "fixed pointer-events-auto inset-0 z-50 bg-background/80 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0"
+        class: [
+          "fixed pointer-events-auto inset-0 z-50 bg-background/80 backdrop-blur-sm",
+          "data-[state=open]:animate-in data-[state=open]:fade-in-0",
+          "data-[state=closed]:animate-out data-[state=closed]:fade-out-0"
+        ]
       )
     end
   end


### PR DESCRIPTION
Based on these articles from
[developer.mozilla.org](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-disabled) | [kittygiraudel.com](https://kittygiraudel.com/2024/03/29/on-disabled-and-aria-disabled-attributes) | [dhiwise.com](https://www.dhiwise.com/post/aria-disabled-vs-disabled-when-to-use-each)  | [a11y-101.com](https://a11y-101.com/development/aria-disabled) | [dev.to](https://dev.to/josefine/making-disabled-buttons-more-accessible-21ih)

It's necessary to provide the support for users who want to use `aria-disabled` instead of `disable`