### PR TITLE
Align destructive button and link variants with shadcn styles

### DIFF
--- a/lib/ruby_ui/button/button.rb
+++ b/lib/ruby_ui/button/button.rb
@@ -72,8 +72,9 @@ module RubyUI
       [
         BASE_CLASSES,
         size_classes,
-        "bg-destructive text-destructive-foreground shadow-sm",
-        "hover:bg-destructive/90"
+        "bg-destructive text-white shadow-sm",
+        "[a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20",
+        "dark:focus-visible:ring-destructive/40 dark:bg-destructive/60"
       ]
     end
 

--- a/lib/ruby_ui/link/link.rb
+++ b/lib/ruby_ui/link/link.rb
@@ -72,8 +72,9 @@ module RubyUI
       [
         BASE_CLASSES,
         size_classes,
-        "bg-destructive text-destructive-foreground shadow-sm",
-        "hover:bg-destructive/90"
+        "bg-destructive text-white shadow-sm",
+        "[a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20",
+        "dark:focus-visible:ring-destructive/40 dark:bg-destructive/60"
       ]
     end
 


### PR DESCRIPTION
I've noticed that ShadCN updated the classes for the destructive variant in both button and link components with the Tailwind CSS v4 update. This PR updates our styles to align with those changes.

<img width="400" alt="Captura de Tela 2025-05-08 às 20 45 19" src="https://github.com/user-attachments/assets/3fc7e081-4d21-4e01-ac01-72c198041a88" />
<img width="400" alt="Captura de Tela 2025-05-08 às 20 45 25" src="https://github.com/user-attachments/assets/3eea02a1-414f-47cb-af8b-39afe50cbb63" />


References:
- https://ui.shadcn.com/docs/tailwind-v4
- https://v4.shadcn.com/