### PR TITLE
Add generator for all components

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ You can generate your components using `ruby_ui:component` generator.
 bin/rails g ruby_ui:component Accordion
 ```
 
+You also can generate all components using `ruby_ui:component:all` generator
+
 ## Documentation 📖
 
 Visit https://rubyui.com/docs/introduction to view the full documentation, including:

--- a/lib/generators/ruby_ui/component/all_generator.rb
+++ b/lib/generators/ruby_ui/component/all_generator.rb
@@ -1,0 +1,24 @@
+module RubyUI
+  module Generators
+    module Component
+      class AllGenerator < Rails::Generators::Base
+
+        namespace "ruby_ui:component:all"
+
+        source_root File.expand_path("../../../ruby_ui", __dir__)
+
+        def generate_components
+          say "Generating all components..."
+
+          Dir.children(self.class.source_root).each do |folder_name|
+            puts "folder_name: #{folder_name}"
+            next if folder_name == "base.rb"
+
+            component_name = folder_name.camelize
+            run "bin/rails generate ruby_ui:component #{component_name} --force true"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/generators/ruby_ui/component_generator.rb
+++ b/lib/generators/ruby_ui/component_generator.rb
@@ -8,6 +8,7 @@ module RubyUI
 
       source_root File.expand_path("../../ruby_ui", __dir__)
       argument :component_name, type: :string, required: true
+      class_option :force, type: :boolean, default: false
 
       def generate_component
         if component_not_found?
@@ -23,7 +24,7 @@ module RubyUI
 
         components_file_paths.each do |file_path|
           component_file_name = file_path.split("/").last
-          copy_file file_path, Rails.root.join("app/components/ruby_ui", component_folder_name, component_file_name)
+          copy_file file_path, Rails.root.join("app/components/ruby_ui", component_folder_name, component_file_name), force: options["force"]
         end
       end
 


### PR DESCRIPTION
Add a new generator that allows users to generate all components at once using the command `bin/rails g ruby_ui:component:all`.

This makes it easier for users who want to install the complete set of components without having to run individual commands for each component.

In my notebook, it's tanking 1m 3s to generate all components. We can improve this but i tried to keep the same approach as the component generator to make it easier to maintain.