### PR TITLE
Fix avatar image placement in Firefox

### DIFF
--- a/lib/ruby_ui/avatar/avatar_image.rb
+++ b/lib/ruby_ui/avatar/avatar_image.rb
@@ -17,7 +17,7 @@ module RubyUI
     def default_attrs
       {
         loading: "lazy",
-        class: "aspect-square h-full w-full",
+        class: "absolute aspect-square h-full w-full z-1",
         alt: @alt,
         src: @src
       }


### PR DESCRIPTION
Fix the avatar image placement on Firefox. Issue #259.

**Before:**
![image](https://github.com/user-attachments/assets/963d164d-827c-4cde-b3f6-c69e326525fd)

**After:**
![image](https://github.com/user-attachments/assets/2d0f26f3-a1f9-4396-9b0d-4489245b0629)
