### PR TITLE
Fix sidebar typo

### DIFF
--- a/lib/ruby_ui/sidebar/collapsible_sidebar.rb
+++ b/lib/ruby_ui/sidebar/collapsible_sidebar.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module RubyUI
-  class CollapsiableSidebar < Base
+  class CollapsibleSidebar < Base
     def initialize(side: :left, variant: :sidebar, collapsible: :offcanvas, open: true, **attrs)
       @side = side
       @variant = variant

--- a/lib/ruby_ui/sidebar/non_collapsible_sidebar.rb
+++ b/lib/ruby_ui/sidebar/non_collapsible_sidebar.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module RubyUI
-  class NonCollpapsibleSidebar < Base
+  class NonCollapsibleSidebar < Base
     def view_template(&)
       div(**attrs, &)
     end

--- a/lib/ruby_ui/sidebar/sidebar.rb
+++ b/lib/ruby_ui/sidebar/sidebar.rb
@@ -20,9 +20,9 @@ module RubyUI
 
     def view_template(&)
       if @collapsible == :none
-        NonCollapsiableSidebar(**attrs, &)
+        NonCollapsibleSidebar(**attrs, &)
       else
-        CollapsiableSidebar(side: @side, variant: @variant, collapsible: @collapsible, open: @open, **attrs, &)
+        CollapsibleSidebar(side: @side, variant: @variant, collapsible: @collapsible, open: @open, **attrs, &)
       end
     end
   end

--- a/test/ruby_ui/sidebar_test.rb
+++ b/test/ruby_ui/sidebar_test.rb
@@ -63,6 +63,66 @@ class RubyUI::SidebarTest < ComponentTest
     assert_match(/Footer/, output)
   end
 
+  def test_render_non_collapsible_sidebar
+    output = phlex do
+      RubyUI.SidebarWrapper do
+        RubyUI.Sidebar(collapsible: :none) do
+          RubyUI.SidebarHeader do
+            RubyUI.SidebarGroup do
+              RubyUI.SidebarGroupContent do
+                RubyUI.SidebarInput(id: "search", placeholder: "Search the docs")
+              end
+            end
+          end
+          RubyUI.SidebarContent do
+            RubyUI.SidebarGroup do
+              RubyUI.SidebarGroupLabel { "Application" }
+              RubyUI.SidebarGroupAction { "Group Action" }
+              RubyUI.SidebarGroupContent do
+                RubyUI.SidebarMenu do
+                  RubyUI.SidebarMenuItem do
+                    RubyUI.SidebarMenuSub do
+                      RubyUI.SidebarMenuSubItem do
+                        RubyUI.SidebarMenuSubButton(as: :a, href: "#") { "Sub Item 1" }
+                      end
+                    end
+                  end
+                  RubyUI.SidebarMenuItem do
+                    RubyUI.SidebarMenuButton(as: :a, href: "#") { "Settings" }
+                    RubyUI.SidebarMenuAction { "Settings" }
+                  end
+                  RubyUI.SidebarMenuItem do
+                    RubyUI.SidebarMenuButton { "Dashboard" }
+                    RubyUI.SidebarMenuAction { "Dashboard" }
+                    RubyUI.SidebarMenuBadge { "Dashboard Badge" }
+                  end
+                  RubyUI.SidebarMenuItem do
+                    RubyUI.SidebarMenuSkeleton()
+                  end
+                end
+              end
+            end
+            RubyUI.SidebarSeparator()
+          end
+          RubyUI.SidebarFooter { "Footer" }
+          RubyUI.SidebarRail()
+        end
+        RubyUI.SidebarInset do
+          RubyUI.SidebarTrigger()
+        end
+      end
+    end
+
+    assert_match(/Search the docs/, output)
+    assert_match(/Application/, output)
+    assert_match(/Group Action/, output)
+    assert_match(/Sub Item 1/, output)
+    assert_match(/Settings/, output)
+    assert_match(/Dashboard/, output)
+    assert_match(/Dashboard Badge/, output)
+    assert_match(/Footer/, output)
+  end
+
   def test_with_side_right
     output = phlex do
       RubyUI.Sidebar(side: :right)


### PR DESCRIPTION
- Fix the `NonCollapsibleSidebar` class name
- Rename the `CollapsiableSidebar` to `CollapsibleSidebar`