### PR TITLE
Fix error in dialog_controller.js by checking for event before calling preventDefault

### DIFF
--- a/lib/ruby_ui/dialog/dialog_controller.js
+++ b/lib/ruby_ui/dialog/dialog_controller.js
@@ -17,7 +17,9 @@ export default class extends Controller {
   }
 
   open(e) {
-    e.preventDefault()
+    if (e) {
+      e.preventDefault();
+    }
     document.body.insertAdjacentHTML('beforeend', this.contentTarget.innerHTML)
     // prevent scroll on body
     document.body.classList.add('overflow-hidden')

--- a/lib/ruby_ui/dialog/dialog_controller.js
+++ b/lib/ruby_ui/dialog/dialog_controller.js
@@ -17,9 +17,7 @@ export default class extends Controller {
   }
 
   open(e) {
-    if (e) {
-      e.preventDefault();
-    }
+    e?.preventDefault();
     document.body.insertAdjacentHTML('beforeend', this.contentTarget.innerHTML)
     // prevent scroll on body
     document.body.classList.add('overflow-hidden')


### PR DESCRIPTION
There is a bug when rendering a dialog in the open state. The connect method tries to call preventDefault() on an event that doesn't exist which causes an error.

Steps to reproduce...

Render the following in a view template and you will get the following error
`TypeError: Cannot read properties of undefined (reading 'preventDefault')`
![CleanShot 2025-05-24 at 19 26 57@2x](https://github.com/user-attachments/assets/0c167d58-ecb9-43f5-a8ac-4cc4c6288e17)

```ruby
render RubyUI::Dialog.new(open: true) do
  render RubyUI::DialogContent.new do
    div do
      "hello"
    end
  end
end
```

This allows the event to be undefined and be able to open without issue.