### PR TITLE
Remove console.logs from stimulus controllers

### DIFF
--- a/lib/ruby_ui/command/command_controller.js
+++ b/lib/ruby_ui/command/command_controller.js
@@ -34,7 +34,6 @@ export default class extends Controller {
     // allow scroll on body
     document.body.classList.remove("overflow-hidden");
     // remove the element
-    console.log("this.element", this.element);
     this.element.remove();
   }
 

--- a/lib/ruby_ui/tooltip/tooltip_controller.js
+++ b/lib/ruby_ui/tooltip/tooltip_controller.js
@@ -23,8 +23,6 @@ export default class extends Controller {
   }
 
   setFloatingElement() {
-    console.log(this.placementValue);
-
     this.cleanup = autoUpdate(this.triggerTarget, this.contentTarget, () => {
       computePosition(this.triggerTarget, this.contentTarget, { placement: this.placementValue, middleware: [offset(4)] }).then(({ x, y }) => {
         Object.assign(this.contentTarget.style, {


### PR DESCRIPTION
I found some console.logs in the stimulus controllers which I don't think are intended to be there.