### PR TITLE
fix the options value naming

### DIFF
--- a/lib/ruby_ui/context_menu/context_menu.rb
+++ b/lib/ruby_ui/context_menu/context_menu.rb
@@ -18,7 +18,7 @@ module RubyUI
       {
         data: {
           controller: "ruby-ui--context-menu",
-          popover_options_value: @options.to_json
+          ruby_ui__context_menu_options_value: @options.to_json
         }
       }
     end


### PR DESCRIPTION
The context_menu component has a options value which is mistakenly named popover_options_value which does not align with the controller name **ruby_ui__context_menu**. This PR corrects the naming so that use can pass options to the context menu.