### PR TITLE
Fixing error on installation

### DIFF
--- a/lib/generators/ruby_ui/install/install_generator.rb
+++ b/lib/generators/ruby_ui/install/install_generator.rb
@@ -42,7 +42,7 @@ module RubyUI
 
       def add_ruby_ui_module_to_components_base
         say "Adding RubyUI Kit to Components::Base"
-        insert_into_file Rails.root.join("app/components/base.rb"), after: "include Phlex::Rails::Helpers::Routes" do
+        insert_into_file Rails.root.join("app/components/base.rb"), after: "class Components::Base < Phlex::HTML" do
           "\n  include RubyUI"
         end
       end


### PR DESCRIPTION
Because [this file](https://github.com/yippee-fun/phlex-rails/blob/main/lib/generators/phlex/install/templates/base_component.rb.erb) changes, we change installer. 
Commit with changes Phelx are: [here](https://github.com/yippee-fun/phlex-rails/commit/1ac6f87bd1763ff6f059df9bc0e402ded26dffff)
Otherwise, an error will occur when executing the command 
`rails g ruby_ui:install`