### PR TITLE
Add and remove classes to fix dropdown positioning issues

### DIFF
--- a/lib/ruby_ui/dropdown_menu/dropdown_menu.rb
+++ b/lib/ruby_ui/dropdown_menu/dropdown_menu.rb
@@ -16,6 +16,7 @@ module RubyUI
     def default_attrs
       {
         class: [
+          "z-50",
           "group/dropdown-menu",
           (strategy == "absolute") ? "is-absolute" : "is-fixed"
         ],

--- a/lib/ruby_ui/dropdown_menu/dropdown_menu_content.rb
+++ b/lib/ruby_ui/dropdown_menu/dropdown_menu_content.rb
@@ -15,7 +15,7 @@ module RubyUI
         data: {
           state: :open
         },
-        class: "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-background p-1 text-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 w-56"
+        class: "z-50 min-w-[8rem] rounded-md border bg-background p-1 text-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 w-56"
       }
     end
 


### PR DESCRIPTION
In our project, we encountered some positioning issues when using other components inside the dropdown.

We rendered a button with a tooltip inside a dropdown item, but the tooltip wasn't displayed correctly:

![image](https://github.com/user-attachments/assets/9f8c01c5-da59-4505-b86f-3a80b610fcb1)

To fix this, we removed the `overflow-hidden` class from the dropdown. After that, the tooltip displayed as expected:

![image](https://github.com/user-attachments/assets/54e24427-3b42-4a69-b5d2-734dfbfd9098)

In another case, a Skeleton component was appearing on top of the dropdown. After some investigation, we discovered that the z-index class needed to be applied directly to the root element of the dropdown to ensure proper stacking.