### PR TITLE
Add checked classes for COMBOBOX + RADIO_BUTTON

### DIFF
--- a/lib/ruby_ui/checkbox/checkbox.rb
+++ b/lib/ruby_ui/checkbox/checkbox.rb
@@ -19,6 +19,7 @@ module RubyUI
         class: [
           "peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background accent-primary",
           "disabled:cursor-not-allowed disabled:opacity-50",
+          "checked:bg-primary checked:text-primary-foreground",
           "aria-disabled:cursor-not-allowed aria-disabled:opacity-50 aria-disabled:pointer-events-none",
           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
         ]

--- a/lib/ruby_ui/combobox/combobox_checkbox.rb
+++ b/lib/ruby_ui/combobox/combobox_checkbox.rb
@@ -14,6 +14,7 @@ module RubyUI
           "peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background accent-primary",
           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
           "disabled:cursor-not-allowed disabled:opacity-50",
+          "checked:bg-primary checked:text-primary-foreground",
           "aria-disabled:cursor-not-allowed aria-disabled:opacity-50 aria-disabled:pointer-events-none"
         ],
         data: {

--- a/lib/ruby_ui/combobox/combobox_checkbox.rb
+++ b/lib/ruby_ui/combobox/combobox_checkbox.rb
@@ -12,10 +12,10 @@ module RubyUI
       {
         class: [
           "peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background accent-primary",
-          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
           "disabled:cursor-not-allowed disabled:opacity-50",
           "checked:bg-primary checked:text-primary-foreground",
-          "aria-disabled:cursor-not-allowed aria-disabled:opacity-50 aria-disabled:pointer-events-none"
+          "aria-disabled:cursor-not-allowed aria-disabled:opacity-50 aria-disabled:pointer-events-none",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
         ],
         data: {
           ruby_ui__combobox_target: "input",

--- a/lib/ruby_ui/combobox/combobox_radio.rb
+++ b/lib/ruby_ui/combobox/combobox_radio.rb
@@ -15,6 +15,7 @@ module RubyUI
           "focus:outline-none",
           "focus-visible:ring-1 focus-visible:ring-ring",
           "disabled:cursor-not-allowed disabled:opacity-50",
+          "checked:bg-primary checked:text-primary-foreground",
           "aria-disabled:cursor-not-allowed aria-disabled:opacity-50 aria-disabled:pointer-events-none"
         ],
         data: {

--- a/lib/ruby_ui/radio_button/radio_button.rb
+++ b/lib/ruby_ui/radio_button/radio_button.rb
@@ -18,6 +18,7 @@ module RubyUI
         class: [
           "h-4 w-4 p-0 border-primary rounded-full flex-none",
           "disabled:cursor-not-allowed disabled:opacity-50",
+          "checked:bg-primary checked:text-primary-foreground",
           "aria-disabled:cursor-not-allowed aria-disabled:opacity-50 aria-disabled:pointer-events-none"
         ]
       }


### PR DESCRIPTION
It is necessary to respect the primary color here

CHECKBOX
![image](https://github.com/user-attachments/assets/03cd89d0-4ccc-4efb-9252-53c968d82497)
![image](https://github.com/user-attachments/assets/9f1d5a7c-6890-4c87-94d3-289fe04b6fd6)

RADIO_BUTTON
![image](https://github.com/user-attachments/assets/7875172a-434c-4847-9893-86f1898f524f)
![image](https://github.com/user-attachments/assets/224b52d8-9d4a-44df-9a30-c4a7d72061ab)