### PR TITLE
[RUBY_UI] FIX Table + DELETE DropdownMenu strategy

### DIFF
--- a/lib/ruby_ui/dropdown_menu/dropdown_menu.rb
+++ b/lib/ruby_ui/dropdown_menu/dropdown_menu.rb
@@ -15,21 +15,13 @@ module RubyUI
 
     def default_attrs
       {
-        class: [
-          "z-50",
-          "group/dropdown-menu",
-          (strategy == "absolute") ? "is-absolute" : "is-fixed"
-        ],
+        class: "z-50",
         data: {
           controller: "ruby-ui--dropdown-menu",
           action: "click@window->ruby-ui--dropdown-menu#onClickOutside",
           ruby_ui__dropdown_menu_options_value: @options.to_json
         }
       }
-    end
-
-    def strategy
-      @_strategy ||= @options[:strategy] || "absolute"
     end
   end
 end

--- a/lib/ruby_ui/dropdown_menu/dropdown_menu_content.rb
+++ b/lib/ruby_ui/dropdown_menu/dropdown_menu_content.rb
@@ -21,10 +21,7 @@ module RubyUI
 
     def wrapper_attrs
       {
-        class: [
-          "z-50 hidden group-[.is-absolute]/dropdown-menu:absolute",
-          "group-[.is-fixed]/dropdown-menu:fixed"
-        ],
+        class: "z-50 hidden absolute",
         data: {ruby_ui__dropdown_menu_target: "content"},
         style: {
           width: "max-content",

--- a/lib/ruby_ui/dropdown_menu/dropdown_menu_controller.js
+++ b/lib/ruby_ui/dropdown_menu/dropdown_menu_controller.js
@@ -45,7 +45,7 @@ export default class extends Controller {
     computePosition(this.triggerTarget, this.contentTarget, {
       placement: this.optionsValue.placement || "top",
       middleware: [flip(), shift(), offset(8)],
-      strategy: this.optionsValue.strategy || "absolute",
+      strategy: "absolute",
     }).then(({ x, y }) => {
       Object.assign(this.contentTarget.style, {
         left: `${x}px`,

--- a/lib/ruby_ui/table/table.rb
+++ b/lib/ruby_ui/table/table.rb
@@ -3,7 +3,7 @@
 module RubyUI
   class Table < Base
     def view_template(&block)
-      div(class: "relative w-full overflow-auto") do
+      div(class: "relative w-full overflow-x-auto") do
         table(**attrs, &block)
       end
     end


### PR DESCRIPTION
Following the [shadcn convention for the table](https://github.com/shadcn-ui/ui/blob/main/apps/v4/registry/new-york-v4/ui/table.tsx)…

I ran into a UI issue with a SELECT inside a TABLE, and upon investigating, I noticed our table implementation differed from shadcn’s. 

After making the necessary adjustments, everything is now working flawlessly — including the DropdownMenu components, which previously had that workaround using the strategy: ‘fixed’.

I also conducted several tests with dropdown_menu within the sidebar, and everything is functioning properly.
<img width="282" height="277" alt="image" src="https://github.com/user-attachments/assets/9fae3fd7-5a2e-4f6a-baba-6e81af6f5cd3" />