### PR TITLE
Improvel tooltip placement

### DIFF
--- a/lib/ruby_ui/tooltip/tooltip_controller.js
+++ b/lib/ruby_ui/tooltip/tooltip_controller.js
@@ -1,5 +1,5 @@
 import { Controller } from "@hotwired/stimulus";
-import { computePosition, autoUpdate, offset } from "@floating-ui/dom";
+import { computePosition, autoUpdate, offset, shift } from "@floating-ui/dom";
 
 export default class extends Controller {
   static targets = ["trigger", "content"];
@@ -24,7 +24,10 @@ export default class extends Controller {
 
   setFloatingElement() {
     this.cleanup = autoUpdate(this.triggerTarget, this.contentTarget, () => {
-      computePosition(this.triggerTarget, this.contentTarget, { placement: this.placementValue, middleware: [offset(4)] }).then(({ x, y }) => {
+      computePosition(this.triggerTarget, this.contentTarget, {
+        placement: this.placementValue,
+        middleware: [offset(4), shift()]
+      }).then(({ x, y }) => {
         Object.assign(this.contentTarget.style, {
           left: `${x}px`,
           top: `${y}px`,


### PR DESCRIPTION
Use [shift](https://floating-ui.com/docs/shift) to improve tooltip placement. 

Before/After:
<img width="1546" height="529" alt="Screenshot 2025-08-14 at 15 51 07" src="https://github.com/user-attachments/assets/1d64bfdc-7f5c-4254-8d07-13c33836e8b5" />
