### PR TITLE
Minor fixes to FormField component styling

### DIFF
--- a/lib/ruby_ui/form/form_field_error.rb
+++ b/lib/ruby_ui/form/form_field_error.rb
@@ -13,7 +13,7 @@ module RubyUI
         data: {
           ruby_ui__form_field_target: "error"
         },
-        class: "text-sm font-medium text-destructive"
+        class: "text-xs font-medium text-destructive"
       }
     end
   end

--- a/lib/ruby_ui/form/form_field_label.rb
+++ b/lib/ruby_ui/form/form_field_label.rb
@@ -11,7 +11,7 @@ module RubyUI
     def default_attrs
       {
         class: [
-          "text-sm font-medium leading-none",
+          "text-sm font-medium leading-none inline-block",
           "peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
           "peer-aria-disabled:cursor-not-allowed peer-aria-disabled:opacity-70 peer-aria-disabled:pointer-events-none"
         ]


### PR DESCRIPTION
Fixes:
- Spacing wasn't being obeyed for FormField as the label was not inline-block
- Error message looked a little big, so I reduced the sizing of this component

See updated design below:

<img width="478" height="122" alt="Screenshot 2025-10-12 at 12 26 36 pm" src="https://github.com/user-attachments/assets/ed4fca1a-ea80-4ece-8365-ce83694a2bb1" />
