### PR TITLE
Fix checkbox contrast in dark mode

### DIFF
--- a/lib/ruby_ui/checkbox/checkbox.rb
+++ b/lib/ruby_ui/checkbox/checkbox.rb
@@ -19,7 +19,7 @@ module RubyUI
         class: [
           "peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background accent-primary",
           "disabled:cursor-not-allowed disabled:opacity-50",
-          "checked:bg-primary checked:text-primary-foreground",
+          "checked:bg-primary checked:text-primary-foreground dark:checked:bg-secondary",
           "aria-disabled:cursor-not-allowed aria-disabled:opacity-50 aria-disabled:pointer-events-none",
           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
         ]


### PR DESCRIPTION
Fixes #320. The contrast for the "check" and the background in dark mode was not enough, making it seem like the checkbox was uncheckable.