### PR TITLE
Fix checkbox and radio button contrast for dark mode

### DIFF
--- a/lib/ruby_ui/checkbox/checkbox.rb
+++ b/lib/ruby_ui/checkbox/checkbox.rb
@@ -17,9 +17,9 @@ module RubyUI
           action: "change->ruby-ui--checkbox-group#onChange change->ruby-ui--form-field#onInput invalid->ruby-ui--form-field#onInvalid"
         },
         class: [
-          "peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background accent-primary",
+          "peer h-4 w-4 shrink-0 rounded-sm border-input ring-offset-background accent-primary",
           "disabled:cursor-not-allowed disabled:opacity-50",
-          "checked:bg-primary checked:text-primary-foreground dark:checked:bg-secondary",
+          "checked:bg-primary checked:text-primary-foreground dark:checked:bg-secondary checked:text-primary checked:border-primary",
           "aria-disabled:cursor-not-allowed aria-disabled:opacity-50 aria-disabled:pointer-events-none",
           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
         ]

--- a/lib/ruby_ui/radio_button/radio_button.rb
+++ b/lib/ruby_ui/radio_button/radio_button.rb
@@ -18,7 +18,7 @@ module RubyUI
         class: [
           "h-4 w-4 p-0 border-primary rounded-full flex-none",
           "disabled:cursor-not-allowed disabled:opacity-50",
-          "checked:bg-primary checked:text-primary-foreground",
+          "checked:bg-primary checked:text-primary-foreground dark:checked:bg-secondary checked:text-primary checked:border-primary",
           "aria-disabled:cursor-not-allowed aria-disabled:opacity-50 aria-disabled:pointer-events-none"
         ]
       }


### PR DESCRIPTION
Fixes #320 

This is a continuation of #323 from @ianmurrays.

This Pull request fixes both the checkbox and the radio button styles when in a dark mode. 

![Nov-19-2025 12-57-56](https://github.com/user-attachments/assets/8fabfd85-0848-46cc-ae72-abbb568c0220)

**Important note:** Shadcn changes the DOM implementation of the checkbox using a button and another element for the indicator. In our case, we rely on the checkbox with a `background-image` default from tailwind. This limits us to use `background-color` and `color` together like shadcn does.