### PR TITLE
Add development mode before_template to Base component

### DIFF
--- a/lib/ruby_ui/base.rb
+++ b/lib/ruby_ui/base.rb
@@ -18,5 +18,12 @@ module RubyUI
     def default_attrs
       {}
     end
+
+    if Rails.env.development?
+      def before_template
+        comment { "Before #{self.class.name}" }
+        super
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary
Adds a `before_template` hook in development mode to the Base component.

## Changes
- Added conditional `before_template` method that only runs in development environment
- Helps with debugging and development workflow by providing insight into component rendering

## Files Changed
- `lib/ruby_ui/base.rb`