### PR TITLE
sheet: Add overflow-scroll to SheetContent

### DIFF
--- a/lib/ruby_ui/sheet/sheet_content.rb
+++ b/lib/ruby_ui/sheet/sheet_content.rb
@@ -33,7 +33,7 @@ module RubyUI
       {
         data_state: "open", # For animate in
         class: [
-          "fixed pointer-events-auto z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
+          "fixed pointer-events-auto z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500 overflow-scroll",
           @side_classes
         ]
       }


### PR DESCRIPTION
## Summary
Adds `overflow-scroll` class to SheetContent component to enable scrolling for long content.

## Changes
- Added `overflow-scroll` to the SheetContent default classes
- Enables scrolling for sheet content when it exceeds the viewport height

## Files Changed
- `lib/ruby_ui/sheet/sheet_content.rb`