### PR TITLE
Improvement | Input type file

### DIFF
--- a/lib/ruby_ui/input/input.rb
+++ b/lib/ruby_ui/input/input.rb
@@ -24,8 +24,9 @@ module RubyUI
           "placeholder:text-muted-foreground",
           "disabled:cursor-not-allowed disabled:opacity-50",
           "file:border-0 file:bg-transparent file:text-sm file:font-medium",
+          "aria-disabled:cursor-not-allowed aria-disabled:opacity-50 aria-disabled:pointer-events-none",
           "focus-visible:outline-none focus-visible:ring-ring/50 focus-visible:ring-2 focus-visible:border-ring focus-visible:shadow-sm",
-          "aria-disabled:cursor-not-allowed aria-disabled:opacity-50 aria-disabled:pointer-events-none"
+          (@type.to_s == "file") ? "pt-[7px]" : ""
         ]
       }
     end


### PR DESCRIPTION
### [Related issue](https://github.com/ruby-ui/ruby_ui/issues/341)

---

FIX padding for `Input(type: "file")`

---

Before | After
:-:|:-:
<img width="408" height="86" alt="image" src="https://github.com/user-attachments/assets/10a24a7a-b095-4096-94b7-9c8e75dcde77" />  |  <img width="410" height="89" alt="image" src="https://github.com/user-attachments/assets/3605a9d1-679c-4e6c-9835-7ff35a9727f8" />