### PR TITLE
Add support for bun package manager

### DIFF
--- a/lib/generators/ruby_ui/javascript_utils.rb
+++ b/lib/generators/ruby_ui/javascript_utils.rb
@@ -4,6 +4,8 @@ module RubyUI
       def install_js_package(package)
         if using_importmap?
           pin_with_importmap(package)
+        elsif using_bun?
+          run "bun add #{package}"
         elsif using_yarn?
           run "yarn add #{package}"
         elsif using_npm?
@@ -29,6 +31,8 @@ module RubyUI
       def using_importmap?
         File.exist?(Rails.root.join("config/importmap.rb")) && File.exist?(Rails.root.join("bin/importmap"))
       end
+
+      def using_bun? = File.exist?(Rails.root.join("bun.lock"))
 
       def using_npm? = File.exist?(Rails.root.join("package-lock.json"))
 


### PR DESCRIPTION
# Summary

A quick pull request to add support for the Bun package manager, which Rails supports when generating new applications.
This avoids the “Could not detect the package manager” message when installing or generating components that require additional JavaScript dependencies.

Thank you!