### PR TITLE
test(table): assert wrapper div has 'relative' class (RUI-5)

### DIFF
--- a/test/ruby_ui/table_test.rb
+++ b/test/ruby_ui/table_test.rb
@@ -43,4 +43,12 @@ class RubyUI::TableTest < ComponentTest
 
     assert_match(/Total/, output)
   end
+
+  def test_render_table_wrapper_has_relative_class
+    output = phlex do
+      RubyUI.Table {}
+    end
+
+    assert_match(/class="relative w-full overflow-auto"/, output)
+  end
 end


### PR DESCRIPTION
## Problem

The `Table` component wraps the `<table>` element in a `div`. Without the `relative` CSS class on that wrapper, absolutely-positioned children (sticky headers, tooltips, overlays) would be positioned relative to the nearest ancestor instead of the table container, causing layout bugs.

## Fix

The fix (`relative w-full overflow-auto` on the wrapper `div`) was already present in the codebase (`lib/ruby_ui/table/table.rb`). However, there was no test asserting this class is rendered, leaving the implementation without regression coverage.

## Changes

- **`test/ruby_ui/table_test.rb`**: Added `test_render_table_wrapper_has_relative_class` which renders a bare `Table` component and asserts the wrapper div contains `class="relative w-full overflow-auto"`.

## Test plan

- [x] `bundle exec rake test` — 75 runs, 328 assertions, 0 failures, 0 errors, 0 skips
- [x] `bundle exec rake standard` — 303 files inspected, no offenses detected