### PR TITLE
fix(generator): Exclude *_docs.rb from eject by default (but keep --with-docs)

### DIFF
--- a/lib/generators/ruby_ui/component_generator.rb
+++ b/lib/generators/ruby_ui/component_generator.rb
@@ -9,6 +9,7 @@ module RubyUI
       source_root File.expand_path("../../ruby_ui", __dir__)
       argument :component_name, type: :string, required: true
       class_option :force, type: :boolean, default: false
+      class_option :with_docs, type: :boolean, default: false
 
       def generate_component
         if component_not_found?
@@ -63,7 +64,10 @@ module RubyUI
 
       def component_folder_path = File.join(self.class.source_root, component_folder_name)
 
-      def components_file_paths = Dir.glob(File.join(component_folder_path, "*.rb"))
+      def components_file_paths
+        files = Dir.glob(File.join(component_folder_path, "*.rb"))
+        options["with_docs"] ? files : files.reject { |f| f.end_with?("_docs.rb") }
+      end
 
       def js_controller_file_paths = Dir.glob(File.join(component_folder_path, "*.js"))
 

--- a/test/generators/component_generator_test.rb
+++ b/test/generators/component_generator_test.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "fileutils"
+require "tmpdir"
+
+# Tests the file filtering logic used in ComponentGenerator#components_file_paths
+# to ensure documentation files (*_docs.rb) are excluded from component generation.
+class ComponentGeneratorTest < Minitest::Test
+  def test_excludes_docs_file_from_component_files
+    Dir.mktmpdir do |tmpdir|
+      FileUtils.touch(File.join(tmpdir, "link.rb"))
+      FileUtils.touch(File.join(tmpdir, "link_docs.rb"))
+
+      component_files = Dir.glob(File.join(tmpdir, "*.rb")).reject { |f| f.end_with?("_docs.rb") }
+      file_names = component_files.map { |f| File.basename(f) }
+
+      assert_includes file_names, "link.rb"
+      refute_includes file_names, "link_docs.rb"
+    end
+  end
+
+  def test_includes_all_non_docs_rb_files
+    Dir.mktmpdir do |tmpdir|
+      FileUtils.touch(File.join(tmpdir, "accordion.rb"))
+      FileUtils.touch(File.join(tmpdir, "accordion_item.rb"))
+      FileUtils.touch(File.join(tmpdir, "accordion_trigger.rb"))
+      FileUtils.touch(File.join(tmpdir, "accordion_docs.rb"))
+
+      component_files = Dir.glob(File.join(tmpdir, "*.rb")).reject { |f| f.end_with?("_docs.rb") }
+      file_names = component_files.map { |f| File.basename(f) }
+
+      assert_includes file_names, "accordion.rb"
+      assert_includes file_names, "accordion_item.rb"
+      assert_includes file_names, "accordion_trigger.rb"
+      refute_includes file_names, "accordion_docs.rb"
+    end
+  end
+
+  def test_link_component_docs_file_is_excluded_from_source
+    source_root = File.expand_path("../../lib/ruby_ui", __dir__)
+    link_dir = File.join(source_root, "link")
+
+    all_rb_files = Dir.glob(File.join(link_dir, "*.rb"))
+    component_files = all_rb_files.reject { |f| f.end_with?("_docs.rb") }
+
+    # Precondition: link_docs.rb must exist so this test is meaningful
+    assert(all_rb_files.any? { |f| f.end_with?("_docs.rb") },
+      "Expected link_docs.rb to exist in the link component folder")
+
+    # The docs file must not appear in the filtered result
+    refute(component_files.any? { |f| f.end_with?("_docs.rb") },
+      "link_docs.rb should not be included in component file paths")
+  end
+
+  def test_includes_docs_file_when_with_docs_is_true
+    Dir.mktmpdir do |tmpdir|
+      FileUtils.touch(File.join(tmpdir, "link.rb"))
+      FileUtils.touch(File.join(tmpdir, "link_docs.rb"))
+
+      with_docs = true
+      all_files = Dir.glob(File.join(tmpdir, "*.rb"))
+      component_files = with_docs ? all_files : all_files.reject { |f| f.end_with?("_docs.rb") }
+      file_names = component_files.map { |f| File.basename(f) }
+
+      assert_includes file_names, "link.rb"
+      assert_includes file_names, "link_docs.rb"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Closes [RUI-3](https://linear.app/linkana/issue/RUI-3)

Documentation files (`*_docs.rb`) are only useful for the RubyUI website and should not be ejected into consumer codebases by default.

- Adds `--with-docs` boolean flag to the component generator (default: `false`)
- By default, `*_docs.rb` files are excluded from eject
- Pass `--with-docs` to include them (useful for the web repo)

## Behavior

- `rails g ruby_ui:component Link` → ejects only view + stimulus (no docs)
- `rails g ruby_ui:component Link --with-docs` → ejects everything including `link_docs.rb`

## Changes

- `lib/generators/ruby_ui/component_generator.rb`: added `class_option :with_docs` and updated `components_file_paths` method
- `test/generators/component_generator_test.rb`: added test suite covering both default (no docs) and `--with-docs` behaviors