### PR TITLE
feat(masked-input): add save_unmasked option to submit raw value

### DIFF
--- a/lib/ruby_ui/masked_input/masked_input.rb
+++ b/lib/ruby_ui/masked_input/masked_input.rb
@@ -2,8 +2,18 @@
 
 module RubyUI
   class MaskedInput < Base
+    def initialize(save_unmasked: false, **attrs)
+      @save_unmasked = save_unmasked
+      super(**attrs)
+    end
+
     def view_template
-      Input(type: "text", **attrs)
+      if @save_unmasked
+        Input(type: "text", **attrs.merge(name: "#{attrs[:name]}-masked"))
+        input(type: "hidden", name: attrs[:name], value: attrs[:value])
+      else
+        Input(type: "text", **attrs)
+      end
     end
 
     private

--- a/lib/ruby_ui/masked_input/masked_input_controller.js
+++ b/lib/ruby_ui/masked_input/masked_input_controller.js
@@ -5,5 +5,18 @@ import { MaskInput } from "maska";
 export default class extends Controller {
   connect() {
     new MaskInput(this.element)
+    this.#boundSync = this.#sync.bind(this);
+    this.element.addEventListener("maska", this.#boundSync);
+  }
+
+  disconnect() {
+    this.element.removeEventListener("maska", this.#boundSync);
+  }
+
+  #boundSync = null;
+
+  #sync(event) {
+    const hidden = this.element.nextElementSibling;
+    if (hidden?.type === "hidden") hidden.value = event.detail.unmasked;
   }
 }

--- a/test/ruby_ui/masked_input_test.rb
+++ b/test/ruby_ui/masked_input_test.rb
@@ -11,5 +11,17 @@ class RubyUI::MaskedInputTest < ComponentTest
     assert_match(/<input type="text"/, output)
     assert_match(/data-controller="ruby-ui--masked-input"/, output)
     assert_match(/data-maska="#####-###"/, output)
+    refute_match(/<input type="hidden"/, output)
+  end
+
+  def test_render_with_save_unmasked
+    output = phlex do
+      RubyUI.MaskedInput(save_unmasked: true, name: "agency", value: "0000", data: {maska: "####"})
+    end
+
+    assert_match(/<input type="text"/, output)
+    assert_match(/<input type="hidden" name="agency" value="0000"/, output)
+    assert_match(/data-maska="####"/, output)
+    assert_match(/data-controller="ruby-ui--masked-input"/, output)
   end
 end


### PR DESCRIPTION
Adds a `save_unmasked` option to `MaskedInput` that, when enabled, submits the raw (unformatted) value instead of the masked one.

## Why

Previously, masked inputs would submit the formatted value to theserver (e.g., `1111 2222` instead of `11112222`), requiring a custom Stimulus controller wrapper as a workaround. This brings the behavior natively into the component.

## How
When `save_unmasked: true` is passed:

- The visible input renders without a `name` attribute (so it's not submitted)
- A hidden input with the original `name` is rendered as its next sibling
- The Stimulus controller listens to the `maska` event and syncs `event.detail.unmasked` to the hidden input on every keystroke

## Usage

```ruby
MaskedInput(
  name: "iban",
  value: @record.iban,
  save_unmasked: true,
  data: { maska: "SSSS SSSS SSSS SSSS", maska_tokens: "S:[A-Z0-9]" }
)
```
