### PR TITLE
Update major Dependabot dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         ruby: ["3.3", "3.4"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -45,7 +45,7 @@ jobs:
           bundler-cache: true
           working-directory: docs
       - name: Install pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@v6
         with:
           version: 10.8.0
           run_install: false

--- a/docs/.devcontainer/devcontainer.json
+++ b/docs/.devcontainer/devcontainer.json
@@ -10,7 +10,7 @@
   "features": {
     "ghcr.io/devcontainers/features/github-cli:1": {},
     "ghcr.io/rails/devcontainer/features/activestorage": {},
-    "ghcr.io/devcontainers/features/node:1": { "version": 20, "pnpmVersion": "10.8.0" },
+    "ghcr.io/devcontainers/features/node:2": { "version": 20, "pnpmVersion": "10.8.0" },
     "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {"moby":false},
     "ghcr.io/rails/devcontainer/features/sqlite3": {}
   },

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -10,7 +10,7 @@ gem "propshaft", "1.3.2"
 # Use sqlite3 as the database for Active Record
 gem "sqlite3", "2.9.4"
 # Use the Puma web server [https://github.com/puma/puma]
-gem "puma", "7.2.0"
+gem "puma", "8.0.1"
 # Bundle and transpile JavaScript [https://github.com/rails/jsbundling-rails]
 gem "jsbundling-rails", "1.3.1"
 # Hotwire's SPA-like page accelerator [https://turbo.hotwired.dev]

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -157,7 +157,7 @@ GEM
     method_source (1.1.0)
     mini_mime (1.1.5)
     mini_portile2 (2.8.9)
-    minitest (6.0.4)
+    minitest (6.0.6)
       drb (~> 2.0)
       prism (~> 1.5)
     msgpack (1.8.0)
@@ -196,7 +196,7 @@ GEM
       date
       stringio
     public_suffix (6.0.1)
-    puma (7.2.0)
+    puma (8.0.1)
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.2.6)
@@ -339,7 +339,7 @@ DEPENDENCIES
   phlex-rails!
   propshaft (= 1.3.2)
   pry (= 0.16.0)
-  puma (= 7.2.0)
+  puma (= 8.0.1)
   rails (= 8.1.3)
   rouge (~> 4.7)
   rss (= 0.3.2)

--- a/gem/Gemfile.lock
+++ b/gem/Gemfile.lock
@@ -7,11 +7,13 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.3)
+    drb (2.2.3)
     json (2.19.5)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
-    lru_redux (1.1.0)
-    minitest (5.25.1)
+    minitest (6.0.6)
+      drb (~> 2.0)
+      prism (~> 1.5)
     parallel (1.28.0)
     parser (3.3.11.1)
       ast (~> 2.4.1)
@@ -47,6 +49,7 @@ GEM
       rubocop (>= 1.75.0, < 2.0)
       rubocop-ast (>= 1.47.1, < 2.0)
     ruby-progressbar (1.13.0)
+    sin_lru_redux (2.5.2)
     standard (1.54.0)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.0)
@@ -59,8 +62,8 @@ GEM
     standard-performance (1.9.0)
       lint_roller (~> 1.1)
       rubocop-performance (~> 1.26.0)
-    tailwind_merge (0.13.2)
-      lru_redux (~> 1.1)
+    tailwind_merge (1.4.0)
+      sin_lru_redux (~> 2.5)
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
     unicode-emoji (4.2.0)
@@ -71,13 +74,13 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  minitest (~> 5.0)
+  minitest (~> 6.0)
   phlex (~> 2.1, >= 2.1.2)
   rake (~> 13.0)
   rouge (~> 4.7.0)
   ruby_ui!
   standard (~> 1.0)
-  tailwind_merge (~> 0.12)
+  tailwind_merge (~> 1.4)
 
 BUNDLED WITH
    2.5.22

--- a/gem/ruby_ui.gemspec
+++ b/gem/ruby_ui.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "phlex", "~> 2.1", ">= 2.1.2"
   s.add_development_dependency "rouge", "~> 4.7.0"
-  s.add_development_dependency "tailwind_merge", "~> 0.12"
+  s.add_development_dependency "tailwind_merge", "~> 1.4"
   s.add_development_dependency "rake", "~> 13.0"
   s.add_development_dependency "standard", "~> 1.0"
-  s.add_development_dependency "minitest", "~> 5.0"
+  s.add_development_dependency "minitest", "~> 6.0"
 end


### PR DESCRIPTION
## Summary
- apply the remaining major Dependabot updates on top of #376
- update gem minitest to 6.0.6 and tailwind_merge to 1.4.0
- update docs puma to 8.0.1 and minitest to 6.0.6
- update GitHub Actions checkout/pnpm setup major versions
- update the docs devcontainer node feature to v2

## Included Dependabot PRs
- Supersedes #360
- Supersedes #361
- Supersedes #363
- Supersedes #367
- Supersedes #370
- Supersedes #371
- Supersedes #373

## Stacking / conflict analysis
- This PR is based on #376 because the major updates touch the same gem and docs lockfiles as the non-major updates.
- Keeping it stacked makes the diff only the major-version delta and avoids duplicated or conflicting Bundler lock resolution.
- After #376 merges, this PR can be retargeted to main or rebased onto main.

## Verification
- docker Ruby 3.4.7: bundle exec rake test
- docker Ruby 3.4.7: bundle exec rake standard
- docker Ruby 3.4.7 + Node 20/pnpm 10.8.0: bundle exec standardrb
- docker Ruby 3.4.7 + Node 20/pnpm 10.8.0: bundle exec rails db:test:prepare test