### PR TITLE
Fix docs header theme toggle and command search

### DIFF
--- a/docs/app/assets/stylesheets/application.tailwind.css
+++ b/docs/app/assets/stylesheets/application.tailwind.css
@@ -3,6 +3,8 @@
 @plugin "@tailwindcss/forms";
 @plugin "@tailwindcss/typography";
 
+/* Safelist classes from RubyUI gem components rendered by the docs app. */
+@source inline("dark:inline-block");
 
 @import "tw-animate-css";
 

--- a/docs/app/components/shared/logo.rb
+++ b/docs/app/components/shared/logo.rb
@@ -9,9 +9,15 @@ module Components
             img(src: image_url("logo.svg"), class: "h-4 block dark:hidden")
             img(src: image_url("logo_dark.svg"), class: "h-4 hidden dark:block")
             span(class: "sr-only") { "RubyUI" }
-            Badge(class: "ml-2 whitespace-nowrap bg-black text-white hover:bg-black/90 px-1.5 py-0.5 rounded-full text-xs font-semibold") { "1.0" }
+            Badge(class: "ml-2 whitespace-nowrap bg-black text-white hover:bg-black/90 px-1.5 py-0.5 rounded-full text-xs font-semibold") { ruby_ui_version }
           }
         end
+      end
+
+      private
+
+      def ruby_ui_version
+        RubyUI::VERSION.split(".").first(2).join(".")
       end
     end
   end

--- a/docs/app/javascript/controllers/ruby_ui/command_controller.js
+++ b/docs/app/javascript/controllers/ruby_ui/command_controller.js
@@ -13,18 +13,30 @@ export default class extends Controller {
   };
 
   connect() {
+    this.selectedIndex = -1;
+
+    if (!this.hasInputTarget) {
+      return;
+    }
+
     this.inputTarget.focus();
     this.searchIndex = this.buildSearchIndex();
     this.toggleVisibility(this.emptyTargets, false);
-    this.selectedIndex = -1;
 
-    if (this.openValue) {
+    if (this.openValue && this.hasContentTarget) {
       this.open();
     }
   }
 
   open(e) {
-    e.preventDefault();
+    if (e) {
+      e.preventDefault();
+    }
+
+    if (!this.hasContentTarget) {
+      return;
+    }
+
     document.body.insertAdjacentHTML("beforeend", this.contentTarget.innerHTML);
     // prevent scroll on body
     document.body.classList.add("overflow-hidden");

--- a/gem/lib/ruby_ui/command/command_controller.js
+++ b/gem/lib/ruby_ui/command/command_controller.js
@@ -13,18 +13,30 @@ export default class extends Controller {
   };
 
   connect() {
+    this.selectedIndex = -1;
+
+    if (!this.hasInputTarget) {
+      return;
+    }
+
     this.inputTarget.focus();
     this.searchIndex = this.buildSearchIndex();
     this.toggleVisibility(this.emptyTargets, false);
-    this.selectedIndex = -1;
 
-    if (this.openValue) {
+    if (this.openValue && this.hasContentTarget) {
       this.open();
     }
   }
 
   open(e) {
-    e.preventDefault();
+    if (e) {
+      e.preventDefault();
+    }
+
+    if (!this.hasContentTarget) {
+      return;
+    }
+
     document.body.insertAdjacentHTML("beforeend", this.contentTarget.innerHTML);
     // prevent scroll on body
     document.body.classList.add("overflow-hidden");


### PR DESCRIPTION
## Summary
- restore Tailwind scanning for local gem component classes used by the docs app
- prevent the command dialog wrapper from requiring an input target before the dialog is opened
- read the header version badge from RubyUI::VERSION

## Tests
- pnpm build
- pnpm build:css
- node --check docs/app/javascript/controllers/ruby_ui/command_controller.js
- node --check gem/lib/ruby_ui/command/command_controller.js
- ruby -c docs/app/components/shared/logo.rb
- git diff --check origin/main..HEAD

Note: Rails tests were not run locally because this shell resolves Ruby 2.6, while docs/.ruby-version requires 3.4.7.