### PR TITLE
fix(docs): scan RubyUI gem classes in Tailwind

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+CLAUDE.local.md

--- a/docs/app/assets/stylesheets/application.tailwind.css
+++ b/docs/app/assets/stylesheets/application.tailwind.css
@@ -3,6 +3,8 @@
 @plugin "@tailwindcss/forms";
 @plugin "@tailwindcss/typography";
 
+@source "../../../../gem/lib/ruby_ui";
+
 /* Safelist classes from RubyUI gem components rendered by the docs app. */
 @source inline("dark:inline-block");
 


### PR DESCRIPTION
## Summary
- Add Tailwind @source for gem/lib/ruby_ui so docs CSS includes classes used by RubyUI components.
- Restores generated utilities that were missed after moving components from web/app/components into the monorepo gem.

## Validation
- docker exec -w /workspaces/ruby_ui/docs a40dac6a897a pnpm run build:css
- docker exec -w /workspaces/ruby_ui/docs a40dac6a897a /home/vscode/.local/bin/mise exec ruby@3.4.7 -- bin/rails test