### PR TITLE
[Bug Fix] Fix SelectValue placeholder fallback

### DIFF
--- a/gem/lib/ruby_ui/select/select_value.rb
+++ b/gem/lib/ruby_ui/select/select_value.rb
@@ -9,7 +9,8 @@ module RubyUI
 
     def view_template(&block)
       span(**attrs) do
-        block ? block.call : @placeholder
+        value = block ? block.call : @placeholder
+        value || @placeholder
       end
     end
 

--- a/gem/test/ruby_ui/select_test.rb
+++ b/gem/test/ruby_ui/select_test.rb
@@ -29,4 +29,14 @@ class RubyUI::SelectTest < ComponentTest
     assert_match(/John/, output)
     assert_match('name="NAME"', output)
   end
+
+  def test_select_value_renders_placeholder_when_block_returns_nil
+    output = phlex do
+      RubyUI.SelectValue(placeholder: "Placeholder") do
+        nil
+      end
+    end
+
+    assert_match(/Placeholder/, output)
+  end
 end


### PR DESCRIPTION
## Summary
- Render the SelectValue placeholder when a provided block returns nil
- Add regression coverage for the nil-block placeholder case

Closes #292

## Testing
- docker run --rm -v /Users/djalmaaraujo/dev/linkana/ruby_ui-issue-292:/workspace -w /workspace/gem ruby:3.4.7 bash -lc 'bundle install && bundle exec rake test TEST=test/ruby_ui/select_test.rb'