### PR TITLE
[Bug Fix] Install Typography with Tooltip

### DIFF
--- a/gem/lib/generators/ruby_ui/dependencies.yml
+++ b/gem/lib/generators/ruby_ui/dependencies.yml
@@ -96,5 +96,8 @@ select:
     - "@floating-ui/dom"
 
 tooltip:
+  components:
+    - "Typography"
+
   js_packages:
     - "@floating-ui/dom"

--- a/gem/test/generators/component_generator_test.rb
+++ b/gem/test/generators/component_generator_test.rb
@@ -75,4 +75,11 @@ class ComponentGeneratorTest < Minitest::Test
 
     assert_equal ["Input", "Popover", "Calendar"], dependencies.fetch("date_picker").fetch("components")
   end
+
+  def test_tooltip_installs_typography_for_text_component
+    dependencies_path = File.expand_path("../../lib/generators/ruby_ui/dependencies.yml", __dir__)
+    dependencies = YAML.load_file(dependencies_path)
+
+    assert_includes dependencies.fetch("tooltip").fetch("components"), "Typography"
+  end
 end


### PR DESCRIPTION
## Summary
- Add Typography as a Tooltip component dependency so the documented Text usage is installed
- Add generator dependency coverage for Tooltip

Closes #296

## Testing
- docker run --rm -v ruby_ui_bundle:/usr/local/bundle -v /Users/djalmaaraujo/dev/linkana/ruby_ui-issue-296:/workspace -w /workspace/gem ruby:3.4.7 bash -lc 'bundle install && bundle exec ruby -Itest test/generators/component_generator_test.rb'