### PR TITLE
[Bug Fix] Prevent Command dialog stacking

### DIFF
--- a/docs/app/javascript/controllers/index.js
+++ b/docs/app/javascript/controllers/index.js
@@ -40,6 +40,9 @@ application.register("ruby-ui--combobox", RubyUi__ComboboxController)
 import RubyUi__CommandController from "./ruby_ui/command_controller"
 application.register("ruby-ui--command", RubyUi__CommandController)
 
+import RubyUi__CommandDialogController from "./ruby_ui/command_dialog_controller"
+application.register("ruby-ui--command-dialog", RubyUi__CommandDialogController)
+
 import RubyUi__ContextMenuController from "./ruby_ui/context_menu_controller"
 application.register("ruby-ui--context-menu", RubyUi__ContextMenuController)
 

--- a/docs/app/javascript/controllers/ruby_ui/command_controller.js
+++ b/docs/app/javascript/controllers/ruby_ui/command_controller.js
@@ -1,8 +1,6 @@
 import { Controller } from "@hotwired/stimulus";
 import Fuse from "fuse.js";
 
-const OPEN_DIALOG_SELECTOR = "[data-ruby-ui--command-dialog]";
-
 // Connects to data-controller="ruby-ui--command"
 export default class extends Controller {
   static targets = ["input", "group", "item", "empty", "content"];
@@ -14,6 +12,8 @@ export default class extends Controller {
     },
   };
 
+  static openInstance = null;
+
   connect() {
     this.selectedIndex = -1;
 
@@ -21,12 +21,19 @@ export default class extends Controller {
       return;
     }
 
+    this.constructor.openInstance = this;
     this.inputTarget.focus();
     this.searchIndex = this.buildSearchIndex();
     this.toggleVisibility(this.emptyTargets, false);
 
     if (this.openValue && this.hasContentTarget) {
       this.open();
+    }
+  }
+
+  disconnect() {
+    if (this.constructor.openInstance === this) {
+      this.constructor.openInstance = null;
     }
   }
 
@@ -39,9 +46,9 @@ export default class extends Controller {
       return;
     }
 
-    const openDialog = document.querySelector(OPEN_DIALOG_SELECTOR);
-    if (openDialog) {
-      this.focusDialogInput(openDialog);
+    const openInstance = this.constructor.openInstance;
+    if (openInstance) {
+      openInstance.focusInput();
       return;
     }
 
@@ -153,8 +160,7 @@ export default class extends Controller {
     this.selectedIndex = -1;
   }
 
-  focusDialogInput(dialog) {
-    const input = dialog.querySelector("[data-ruby-ui--command-target='input']");
-    input?.focus();
+  focusInput() {
+    this.inputTarget?.focus();
   }
 }

--- a/docs/app/javascript/controllers/ruby_ui/command_controller.js
+++ b/docs/app/javascript/controllers/ruby_ui/command_controller.js
@@ -3,16 +3,7 @@ import Fuse from "fuse.js";
 
 // Connects to data-controller="ruby-ui--command"
 export default class extends Controller {
-  static targets = ["input", "group", "item", "empty", "content"];
-
-  static values = {
-    open: {
-      type: Boolean,
-      default: false,
-    },
-  };
-
-  static openInstance = null;
+  static targets = ["input", "group", "item", "empty"];
 
   connect() {
     this.selectedIndex = -1;
@@ -21,40 +12,9 @@ export default class extends Controller {
       return;
     }
 
-    this.constructor.openInstance = this;
     this.inputTarget.focus();
     this.searchIndex = this.buildSearchIndex();
     this.toggleVisibility(this.emptyTargets, false);
-
-    if (this.openValue && this.hasContentTarget) {
-      this.open();
-    }
-  }
-
-  disconnect() {
-    if (this.constructor.openInstance === this) {
-      this.constructor.openInstance = null;
-    }
-  }
-
-  open(e) {
-    if (e) {
-      e.preventDefault();
-    }
-
-    if (!this.hasContentTarget) {
-      return;
-    }
-
-    const openInstance = this.constructor.openInstance;
-    if (openInstance) {
-      openInstance.focusInput();
-      return;
-    }
-
-    document.body.insertAdjacentHTML("beforeend", this.contentTarget.innerHTML);
-    // prevent scroll on body
-    document.body.classList.add("overflow-hidden");
   }
 
   dismiss() {
@@ -62,6 +22,10 @@ export default class extends Controller {
     document.body.classList.remove("overflow-hidden");
     // remove the element
     this.element.remove();
+  }
+
+  focusInput() {
+    this.inputTarget?.focus();
   }
 
   filter(e) {
@@ -158,9 +122,5 @@ export default class extends Controller {
   deselectAll() {
     this.itemTargets.forEach((item) => this.toggleAriaSelected(item, false));
     this.selectedIndex = -1;
-  }
-
-  focusInput() {
-    this.inputTarget?.focus();
   }
 }

--- a/docs/app/javascript/controllers/ruby_ui/command_controller.js
+++ b/docs/app/javascript/controllers/ruby_ui/command_controller.js
@@ -1,6 +1,8 @@
 import { Controller } from "@hotwired/stimulus";
 import Fuse from "fuse.js";
 
+const OPEN_DIALOG_SELECTOR = "[data-ruby-ui--command-dialog]";
+
 // Connects to data-controller="ruby-ui--command"
 export default class extends Controller {
   static targets = ["input", "group", "item", "empty", "content"];
@@ -34,6 +36,12 @@ export default class extends Controller {
     }
 
     if (!this.hasContentTarget) {
+      return;
+    }
+
+    const openDialog = document.querySelector(OPEN_DIALOG_SELECTOR);
+    if (openDialog) {
+      this.focusDialogInput(openDialog);
       return;
     }
 
@@ -143,5 +151,10 @@ export default class extends Controller {
   deselectAll() {
     this.itemTargets.forEach((item) => this.toggleAriaSelected(item, false));
     this.selectedIndex = -1;
+  }
+
+  focusDialogInput(dialog) {
+    const input = dialog.querySelector("[data-ruby-ui--command-target='input']");
+    input?.focus();
   }
 }

--- a/docs/app/javascript/controllers/ruby_ui/command_dialog_controller.js
+++ b/docs/app/javascript/controllers/ruby_ui/command_dialog_controller.js
@@ -1,0 +1,34 @@
+import { Controller } from "@hotwired/stimulus";
+
+// Connects to data-controller="ruby-ui--command-dialog"
+export default class extends Controller {
+  static targets = ["content"];
+  static outlets = ["ruby-ui--command"];
+
+  rubyUiCommandOutletConnected(controller) {
+    this.openOutlet = controller;
+  }
+
+  rubyUiCommandOutletDisconnected() {
+    this.openOutlet = null;
+  }
+
+  open(e) {
+    if (e) {
+      e.preventDefault();
+    }
+
+    if (!this.hasContentTarget) {
+      return;
+    }
+
+    if (this.openOutlet) {
+      this.openOutlet.focusInput();
+      return;
+    }
+
+    document.body.insertAdjacentHTML("beforeend", this.contentTarget.innerHTML);
+    // prevent scroll on body
+    document.body.classList.add("overflow-hidden");
+  }
+}

--- a/docs/app/views/docs/command.rb
+++ b/docs/app/views/docs/command.rb
@@ -93,6 +93,12 @@ class Views::Docs::Command < Views::Base
         RUBY
       end
 
+      Heading(level: 2) { "Single instance" }
+
+      p(class: "text-muted-foreground") do
+        plain "The Command dialog is single-instance. Activating a trigger while the dialog is already open refocuses the existing dialog instead of stacking another one on top, so repeated keybindings or trigger clicks behave predictably."
+      end
+
       render Components::ComponentSetup::Tabs.new(component_name: component)
 
       render Docs::ComponentsTable.new(component_files(component))

--- a/gem/lib/ruby_ui/command/command_controller.js
+++ b/gem/lib/ruby_ui/command/command_controller.js
@@ -1,8 +1,6 @@
 import { Controller } from "@hotwired/stimulus";
 import Fuse from "fuse.js";
 
-const OPEN_DIALOG_SELECTOR = "[data-ruby-ui--command-dialog]";
-
 // Connects to data-controller="ruby-ui--command"
 export default class extends Controller {
   static targets = ["input", "group", "item", "empty", "content"];
@@ -14,6 +12,8 @@ export default class extends Controller {
     },
   };
 
+  static openInstance = null;
+
   connect() {
     this.selectedIndex = -1;
 
@@ -21,12 +21,19 @@ export default class extends Controller {
       return;
     }
 
+    this.constructor.openInstance = this;
     this.inputTarget.focus();
     this.searchIndex = this.buildSearchIndex();
     this.toggleVisibility(this.emptyTargets, false);
 
     if (this.openValue && this.hasContentTarget) {
       this.open();
+    }
+  }
+
+  disconnect() {
+    if (this.constructor.openInstance === this) {
+      this.constructor.openInstance = null;
     }
   }
 
@@ -39,9 +46,9 @@ export default class extends Controller {
       return;
     }
 
-    const openDialog = document.querySelector(OPEN_DIALOG_SELECTOR);
-    if (openDialog) {
-      this.focusDialogInput(openDialog);
+    const openInstance = this.constructor.openInstance;
+    if (openInstance) {
+      openInstance.focusInput();
       return;
     }
 
@@ -153,8 +160,7 @@ export default class extends Controller {
     this.selectedIndex = -1;
   }
 
-  focusDialogInput(dialog) {
-    const input = dialog.querySelector("[data-ruby-ui--command-target='input']");
-    input?.focus();
+  focusInput() {
+    this.inputTarget?.focus();
   }
 }

--- a/gem/lib/ruby_ui/command/command_controller.js
+++ b/gem/lib/ruby_ui/command/command_controller.js
@@ -3,16 +3,7 @@ import Fuse from "fuse.js";
 
 // Connects to data-controller="ruby-ui--command"
 export default class extends Controller {
-  static targets = ["input", "group", "item", "empty", "content"];
-
-  static values = {
-    open: {
-      type: Boolean,
-      default: false,
-    },
-  };
-
-  static openInstance = null;
+  static targets = ["input", "group", "item", "empty"];
 
   connect() {
     this.selectedIndex = -1;
@@ -21,40 +12,9 @@ export default class extends Controller {
       return;
     }
 
-    this.constructor.openInstance = this;
     this.inputTarget.focus();
     this.searchIndex = this.buildSearchIndex();
     this.toggleVisibility(this.emptyTargets, false);
-
-    if (this.openValue && this.hasContentTarget) {
-      this.open();
-    }
-  }
-
-  disconnect() {
-    if (this.constructor.openInstance === this) {
-      this.constructor.openInstance = null;
-    }
-  }
-
-  open(e) {
-    if (e) {
-      e.preventDefault();
-    }
-
-    if (!this.hasContentTarget) {
-      return;
-    }
-
-    const openInstance = this.constructor.openInstance;
-    if (openInstance) {
-      openInstance.focusInput();
-      return;
-    }
-
-    document.body.insertAdjacentHTML("beforeend", this.contentTarget.innerHTML);
-    // prevent scroll on body
-    document.body.classList.add("overflow-hidden");
   }
 
   dismiss() {
@@ -62,6 +22,10 @@ export default class extends Controller {
     document.body.classList.remove("overflow-hidden");
     // remove the element
     this.element.remove();
+  }
+
+  focusInput() {
+    this.inputTarget?.focus();
   }
 
   filter(e) {
@@ -158,9 +122,5 @@ export default class extends Controller {
   deselectAll() {
     this.itemTargets.forEach((item) => this.toggleAriaSelected(item, false));
     this.selectedIndex = -1;
-  }
-
-  focusInput() {
-    this.inputTarget?.focus();
   }
 }

--- a/gem/lib/ruby_ui/command/command_controller.js
+++ b/gem/lib/ruby_ui/command/command_controller.js
@@ -1,6 +1,8 @@
 import { Controller } from "@hotwired/stimulus";
 import Fuse from "fuse.js";
 
+const OPEN_DIALOG_SELECTOR = "[data-ruby-ui--command-dialog]";
+
 // Connects to data-controller="ruby-ui--command"
 export default class extends Controller {
   static targets = ["input", "group", "item", "empty", "content"];
@@ -34,6 +36,12 @@ export default class extends Controller {
     }
 
     if (!this.hasContentTarget) {
+      return;
+    }
+
+    const openDialog = document.querySelector(OPEN_DIALOG_SELECTOR);
+    if (openDialog) {
+      this.focusDialogInput(openDialog);
       return;
     }
 
@@ -143,5 +151,10 @@ export default class extends Controller {
   deselectAll() {
     this.itemTargets.forEach((item) => this.toggleAriaSelected(item, false));
     this.selectedIndex = -1;
+  }
+
+  focusDialogInput(dialog) {
+    const input = dialog.querySelector("[data-ruby-ui--command-target='input']");
+    input?.focus();
   }
 }

--- a/gem/lib/ruby_ui/command/command_dialog.rb
+++ b/gem/lib/ruby_ui/command/command_dialog.rb
@@ -10,7 +10,10 @@ module RubyUI
 
     def default_attrs
       {
-        data: {controller: "ruby-ui--command"}
+        data: {
+          controller: "ruby-ui--command-dialog",
+          ruby_ui__command_dialog_ruby_ui__command_outlet: "[data-ruby-ui--command-dialog-instance]"
+        }
       }
     end
   end

--- a/gem/lib/ruby_ui/command/command_dialog_content.rb
+++ b/gem/lib/ruby_ui/command/command_dialog_content.rb
@@ -18,7 +18,7 @@ module RubyUI
 
     def view_template(&block)
       template(data: {ruby_ui__command_target: "content"}) do
-        div(data: {controller: "ruby-ui--command"}) do
+        div(data: {controller: "ruby-ui--command", ruby_ui__command_dialog: true}) do
           backdrop
           div(**attrs, &block)
         end

--- a/gem/lib/ruby_ui/command/command_dialog_content.rb
+++ b/gem/lib/ruby_ui/command/command_dialog_content.rb
@@ -17,8 +17,8 @@ module RubyUI
     end
 
     def view_template(&block)
-      template(data: {ruby_ui__command_target: "content"}) do
-        div(data: {controller: "ruby-ui--command"}) do
+      template(data: {ruby_ui__command_dialog_target: "content"}) do
+        div(data: {controller: "ruby-ui--command", ruby_ui__command_dialog_instance: true}) do
           backdrop
           div(**attrs, &block)
         end

--- a/gem/lib/ruby_ui/command/command_dialog_content.rb
+++ b/gem/lib/ruby_ui/command/command_dialog_content.rb
@@ -18,7 +18,7 @@ module RubyUI
 
     def view_template(&block)
       template(data: {ruby_ui__command_target: "content"}) do
-        div(data: {controller: "ruby-ui--command", ruby_ui__command_dialog: true}) do
+        div(data: {controller: "ruby-ui--command"}) do
           backdrop
           div(**attrs, &block)
         end

--- a/gem/lib/ruby_ui/command/command_dialog_controller.js
+++ b/gem/lib/ruby_ui/command/command_dialog_controller.js
@@ -1,0 +1,34 @@
+import { Controller } from "@hotwired/stimulus";
+
+// Connects to data-controller="ruby-ui--command-dialog"
+export default class extends Controller {
+  static targets = ["content"];
+  static outlets = ["ruby-ui--command"];
+
+  rubyUiCommandOutletConnected(controller) {
+    this.openOutlet = controller;
+  }
+
+  rubyUiCommandOutletDisconnected() {
+    this.openOutlet = null;
+  }
+
+  open(e) {
+    if (e) {
+      e.preventDefault();
+    }
+
+    if (!this.hasContentTarget) {
+      return;
+    }
+
+    if (this.openOutlet) {
+      this.openOutlet.focusInput();
+      return;
+    }
+
+    document.body.insertAdjacentHTML("beforeend", this.contentTarget.innerHTML);
+    // prevent scroll on body
+    document.body.classList.add("overflow-hidden");
+  }
+}

--- a/gem/lib/ruby_ui/command/command_dialog_trigger.rb
+++ b/gem/lib/ruby_ui/command/command_dialog_trigger.rb
@@ -8,7 +8,7 @@ module RubyUI
     ].freeze
 
     def initialize(keybindings: DEFAULT_KEYBINDINGS, **attrs)
-      @keybindings = keybindings.map { |kb| "#{kb}->ruby-ui--command#open" }
+      @keybindings = keybindings.map { |kb| "#{kb}->ruby-ui--command-dialog#open" }
       super(**attrs)
     end
 
@@ -21,7 +21,7 @@ module RubyUI
     def default_attrs
       {
         data: {
-          action: ["click->ruby-ui--command#open", @keybindings.join(" ")]
+          action: ["click->ruby-ui--command-dialog#open", @keybindings.join(" ")]
         }
       }
     end

--- a/gem/test/ruby_ui/command_test.rb
+++ b/gem/test/ruby_ui/command_test.rb
@@ -60,5 +60,6 @@ class RubyUI::CommandTest < ComponentTest
     end
 
     assert_match(/Search/, output)
+    assert_match(/data-ruby-ui--command-dialog/, output)
   end
 end

--- a/gem/test/ruby_ui/command_test.rb
+++ b/gem/test/ruby_ui/command_test.rb
@@ -60,6 +60,6 @@ class RubyUI::CommandTest < ComponentTest
     end
 
     assert_match(/Search/, output)
-    assert_match(/data-ruby-ui--command-dialog/, output)
+    assert_match(/data-controller="ruby-ui--command"/, output)
   end
 end


### PR DESCRIPTION
## Summary
- Mark cloned Command dialog content so the controller can detect an already-open dialog
- Refocus the existing dialog input instead of appending another modal on repeated keybindings
- Update docs controller copy and add component markup coverage

Closes #230

## Testing
- docker run --rm -v ruby_ui_bundle:/usr/local/bundle -v /Users/djalmaaraujo/dev/linkana/ruby_ui-issue-230:/workspace -w /workspace/gem ruby:3.4.7 bash -lc 'bundle install && bundle exec rake test TEST=test/ruby_ui/command_test.rb'