### PR TITLE
[Bug Fix] Add Avatar image fallback handling

### DIFF
--- a/docs/app/javascript/controllers/index.js
+++ b/docs/app/javascript/controllers/index.js
@@ -13,6 +13,9 @@ application.register("ruby-ui--accordion", RubyUi__AccordionController)
 import RubyUi__AlertDialogController from "./ruby_ui/alert_dialog_controller"
 application.register("ruby-ui--alert-dialog", RubyUi__AlertDialogController)
 
+import RubyUi__AvatarController from "./ruby_ui/avatar_controller"
+application.register("ruby-ui--avatar", RubyUi__AvatarController)
+
 import RubyUi__CalendarController from "./ruby_ui/calendar_controller"
 application.register("ruby-ui--calendar", RubyUi__CalendarController)
 

--- a/docs/app/javascript/controllers/ruby_ui/avatar_controller.js
+++ b/docs/app/javascript/controllers/ruby_ui/avatar_controller.js
@@ -1,0 +1,29 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  static targets = ["image", "fallback"];
+
+  connect() {
+    if (!this.hasImageTarget) return;
+
+    if (this.imageTarget.complete && this.imageTarget.naturalWidth > 0) {
+      this.showImage();
+    } else {
+      this.showFallback();
+    }
+  }
+
+  showImage() {
+    this.imageTargets.forEach((image) => image.classList.remove("hidden"));
+    this.fallbackTargets.forEach((fallback) =>
+      fallback.classList.add("hidden"),
+    );
+  }
+
+  showFallback() {
+    this.imageTargets.forEach((image) => image.classList.add("hidden"));
+    this.fallbackTargets.forEach((fallback) =>
+      fallback.classList.remove("hidden"),
+    );
+  }
+}

--- a/gem/lib/ruby_ui/avatar/avatar.rb
+++ b/gem/lib/ruby_ui/avatar/avatar.rb
@@ -24,6 +24,9 @@ module RubyUI
 
     def default_attrs
       {
+        data: {
+          controller: "ruby-ui--avatar"
+        },
         class: ["relative flex shrink-0 overflow-hidden rounded-full", @size_classes]
       }
     end

--- a/gem/lib/ruby_ui/avatar/avatar_controller.js
+++ b/gem/lib/ruby_ui/avatar/avatar_controller.js
@@ -4,11 +4,15 @@ export default class extends Controller {
   static targets = ["image", "fallback"];
 
   connect() {
-    if (!this.hasImageTarget) return;
+    if (!this.hasImageTarget) {
+      return;
+    }
 
     if (this.imageTarget.complete && this.imageTarget.naturalWidth > 0) {
       this.showImage();
     } else {
+      // Image not yet loaded (or failed): hide it so the fallback shows.
+      // Image visibility is restored by the load/error handlers.
       this.showFallback();
     }
   }

--- a/gem/lib/ruby_ui/avatar/avatar_controller.js
+++ b/gem/lib/ruby_ui/avatar/avatar_controller.js
@@ -1,0 +1,29 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  static targets = ["image", "fallback"];
+
+  connect() {
+    if (!this.hasImageTarget) return;
+
+    if (this.imageTarget.complete && this.imageTarget.naturalWidth > 0) {
+      this.showImage();
+    } else {
+      this.showFallback();
+    }
+  }
+
+  showImage() {
+    this.imageTargets.forEach((image) => image.classList.remove("hidden"));
+    this.fallbackTargets.forEach((fallback) =>
+      fallback.classList.add("hidden"),
+    );
+  }
+
+  showFallback() {
+    this.imageTargets.forEach((image) => image.classList.add("hidden"));
+    this.fallbackTargets.forEach((fallback) =>
+      fallback.classList.remove("hidden"),
+    );
+  }
+}

--- a/gem/lib/ruby_ui/avatar/avatar_fallback.rb
+++ b/gem/lib/ruby_ui/avatar/avatar_fallback.rb
@@ -10,6 +10,9 @@ module RubyUI
 
     def default_attrs
       {
+        data: {
+          ruby_ui__avatar_target: "fallback"
+        },
         class: "flex h-full w-full items-center justify-center rounded-full bg-muted"
       }
     end

--- a/gem/lib/ruby_ui/avatar/avatar_image.rb
+++ b/gem/lib/ruby_ui/avatar/avatar_image.rb
@@ -21,7 +21,7 @@ module RubyUI
           ruby_ui__avatar_target: "image",
           action: "load->ruby-ui--avatar#showImage error->ruby-ui--avatar#showFallback"
         },
-        class: "hidden aspect-square h-full w-full",
+        class: "aspect-square h-full w-full",
         alt: @alt,
         src: @src
       }

--- a/gem/lib/ruby_ui/avatar/avatar_image.rb
+++ b/gem/lib/ruby_ui/avatar/avatar_image.rb
@@ -17,7 +17,11 @@ module RubyUI
     def default_attrs
       {
         loading: "lazy",
-        class: "aspect-square h-full w-full",
+        data: {
+          ruby_ui__avatar_target: "image",
+          action: "load->ruby-ui--avatar#showImage error->ruby-ui--avatar#showFallback"
+        },
+        class: "hidden aspect-square h-full w-full",
         alt: @alt,
         src: @src
       }

--- a/gem/test/ruby_ui/avatar_test.rb
+++ b/gem/test/ruby_ui/avatar_test.rb
@@ -16,6 +16,7 @@ class RubyUI::AvatarTest < ComponentTest
     assert_match(/data-ruby-ui--avatar-target="image"/, output)
     assert_match(/load->ruby-ui--avatar#showImage error->ruby-ui--avatar#showFallback/, output)
     assert_match(/data-ruby-ui--avatar-target="fallback"/, output)
-    assert_match(/hidden aspect-square/, output)
+    assert_match(/class="aspect-square h-full w-full"/, output)
+    refute_match(/class="[^"]*\bhidden\b[^"]*aspect-square/, output)
   end
 end

--- a/gem/test/ruby_ui/avatar_test.rb
+++ b/gem/test/ruby_ui/avatar_test.rb
@@ -12,5 +12,10 @@ class RubyUI::AvatarTest < ComponentTest
     end
 
     assert_match(/joeldrapper/, output)
+    assert_match(/data-controller="ruby-ui--avatar"/, output)
+    assert_match(/data-ruby-ui--avatar-target="image"/, output)
+    assert_match(/load->ruby-ui--avatar#showImage error->ruby-ui--avatar#showFallback/, output)
+    assert_match(/data-ruby-ui--avatar-target="fallback"/, output)
+    assert_match(/hidden aspect-square/, output)
   end
 end


### PR DESCRIPTION
## Summary
- Add a CSP-friendly Stimulus controller for Avatar load/error handling
- Hide AvatarImage until it loads successfully and keep AvatarFallback visible on load failures
- Register the docs controller copy and add component markup coverage

Closes #259

## Testing
- docker run --rm -v ruby_ui_bundle:/usr/local/bundle -v /Users/djalmaaraujo/dev/linkana/ruby_ui-issue-259:/workspace -w /workspace/gem ruby:3.4.7 bash -lc 'bundle install && bundle exec rake test TEST=test/ruby_ui/avatar_test.rb'