### PR TITLE
[Improvement] Add exit animation, remove delay, lazy-mount Tooltip content

### DIFF
--- a/docs/app/javascript/controllers/ruby_ui/tooltip_controller.js
+++ b/docs/app/javascript/controllers/ruby_ui/tooltip_controller.js
@@ -3,36 +3,72 @@ import { computePosition, autoUpdate, offset, shift } from "@floating-ui/dom";
 
 export default class extends Controller {
   static targets = ["trigger", "content"];
-  static values = { placement: String }
 
-  constructor(...args) {
-    super(...args);
-    this.cleanup;
+  static values = { placement: "top" };
+
+  mount() {
+    if (this.mounted) return;
+
+    const element = this.cloneTemplate();
+    element.setAttribute("data-placement", this.placementValue);
+    document.body.appendChild(element);
+
+    this.triggerTarget.setAttribute("aria-describedby", element.id);
+    element.addEventListener("animationend", (event) => this.animationEnd(event));
+
+    const onBeforeCache = () => this.unmount();
+    document.addEventListener("turbo:before-cache", onBeforeCache);
+
+    this.mounted = { element, onBeforeCache };
+    this.mounted.stopAutoUpdate = autoUpdate(this.triggerTarget, element, () => this.reposition());
   }
 
-  connect() {
-    this.setFloatingElement();
+  unmount() {
+    if (!this.mounted) return;
 
-    const tooltipId = this.contentTarget.getAttribute("id");
-    this.triggerTarget.setAttribute("aria-describedby", tooltipId);
+    document.removeEventListener("turbo:before-cache", this.mounted.onBeforeCache);
 
+    this.mounted.stopAutoUpdate?.();
+    this.mounted.element.remove();
+    this.triggerTarget.removeAttribute("aria-describedby");
+
+    this.mounted = null;
   }
 
   disconnect() {
-    this.cleanup();
+    this.unmount();
   }
 
-  setFloatingElement() {
-    this.cleanup = autoUpdate(this.triggerTarget, this.contentTarget, () => {
-      computePosition(this.triggerTarget, this.contentTarget, {
-        placement: this.placementValue,
-        middleware: [offset(4), shift()]
-      }).then(({ x, y }) => {
-        Object.assign(this.contentTarget.style, {
-          left: `${x}px`,
-          top: `${y}px`,
-        });
-      });
+  show() {
+    if (!this.hasContentTarget) return;
+
+    this.mount();
+    this.mounted.element.setAttribute("data-state", "open");
+  }
+
+  hide() {
+    this.mounted?.element.setAttribute("data-state", "closed");
+  }
+
+  animationEnd(event) {
+    if (event.animationName !== "exit") return;
+    if (this.mounted?.element.getAttribute("data-state") !== "closed") return;
+
+    this.unmount();
+  }
+
+  cloneTemplate() {
+    return this.contentTarget.content.firstElementChild.cloneNode(true);
+  }
+
+  reposition() {
+    if (!this.mounted) return;
+
+    const position = { placement: this.placementValue, middleware: [offset(4), shift()] };
+
+    computePosition(this.triggerTarget, this.mounted.element, position).then(({ x, y }) => {
+      this.mounted?.element.style.setProperty("left", `${x}px`);
+      this.mounted?.element.style.setProperty("top", `${y}px`);
     });
   }
 }

--- a/gem/lib/ruby_ui/tooltip/tooltip_content.rb
+++ b/gem/lib/ruby_ui/tooltip/tooltip_content.rb
@@ -18,7 +18,15 @@ module RubyUI
     def default_attrs
       {
         id: @id,
-        class: "invisible pointer-events-none w-fit max-w-[calc(100vw-2rem)] text-balance break-words absolute top-0 left-0 z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md data-[state=open]:visible data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[state=closed]:visible data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=closed]:fill-mode-forwards data-[placement=bottom]:slide-in-from-top-2 data-[placement=left]:slide-in-from-right-2 data-[placement=right]:slide-in-from-left-2 data-[placement=top]:slide-in-from-bottom-2"
+        class: [
+          "invisible pointer-events-none w-fit max-w-[calc(100vw-2rem)] text-balance break-words absolute top-0 left-0 z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md",
+          "data-[placement=bottom]:slide-in-from-top-2",
+          "data-[placement=left]:slide-in-from-right-2",
+          "data-[placement=right]:slide-in-from-left-2",
+          "data-[placement=top]:slide-in-from-bottom-2",
+          "data-[state=open]:visible data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          "data-[state=closed]:visible data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=closed]:fill-mode-forwards"
+        ]
       }
     end
   end

--- a/gem/lib/ruby_ui/tooltip/tooltip_content.rb
+++ b/gem/lib/ruby_ui/tooltip/tooltip_content.rb
@@ -8,7 +8,9 @@ module RubyUI
     end
 
     def view_template(&)
-      div(**attrs, &)
+      template(data: {ruby_ui__tooltip_target: "content"}) do
+        div(**attrs, &)
+      end
     end
 
     private
@@ -16,10 +18,7 @@ module RubyUI
     def default_attrs
       {
         id: @id,
-        data: {
-          ruby_ui__tooltip_target: "content"
-        },
-        class: "invisible peer-hover:visible peer-focus:visible w-fit max-w-[calc(100vw-2rem)] text-balance break-words absolute top-0 left-0 z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md peer-focus:zoom-in-95 animate-out fade-out-0 zoom-out-95 peer-hover:animate-in peer-focus:animate-in peer-hover:fade-in-0 peer-focus:fade-in-0 peer-hover:zoom-in-95 group-data-[ruby-ui--tooltip-placement-value=bottom]:slide-in-from-top-2 group-data-[ruby-ui--tooltip-placement-value=left]:slide-in-from-right-2 group-data-[ruby-ui--tooltip-placement-value=right]:slide-in-from-left-2 group-data-[ruby-ui--tooltip-placement-value=top]:slide-in-from-bottom-2 delay-500"
+        class: "invisible pointer-events-none w-fit max-w-[calc(100vw-2rem)] text-balance break-words absolute top-0 left-0 z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md data-[state=open]:visible data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[state=closed]:visible data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=closed]:fill-mode-forwards data-[placement=bottom]:slide-in-from-top-2 data-[placement=left]:slide-in-from-right-2 data-[placement=right]:slide-in-from-left-2 data-[placement=top]:slide-in-from-bottom-2"
       }
     end
   end

--- a/gem/lib/ruby_ui/tooltip/tooltip_controller.js
+++ b/gem/lib/ruby_ui/tooltip/tooltip_controller.js
@@ -3,36 +3,72 @@ import { computePosition, autoUpdate, offset, shift } from "@floating-ui/dom";
 
 export default class extends Controller {
   static targets = ["trigger", "content"];
-  static values = { placement: String }
 
-  constructor(...args) {
-    super(...args);
-    this.cleanup;
+  static values = { placement: "top" };
+
+  mount() {
+    if (this.mounted) return;
+
+    const element = this.cloneTemplate();
+    element.setAttribute("data-placement", this.placementValue);
+    document.body.appendChild(element);
+
+    this.triggerTarget.setAttribute("aria-describedby", element.id);
+    element.addEventListener("animationend", (event) => this.animationEnd(event));
+
+    const onBeforeCache = () => this.unmount();
+    document.addEventListener("turbo:before-cache", onBeforeCache);
+
+    this.mounted = { element, onBeforeCache };
+    this.mounted.stopAutoUpdate = autoUpdate(this.triggerTarget, element, () => this.reposition());
   }
 
-  connect() {
-    this.setFloatingElement();
+  unmount() {
+    if (!this.mounted) return;
 
-    const tooltipId = this.contentTarget.getAttribute("id");
-    this.triggerTarget.setAttribute("aria-describedby", tooltipId);
+    document.removeEventListener("turbo:before-cache", this.mounted.onBeforeCache);
 
+    this.mounted.stopAutoUpdate?.();
+    this.mounted.element.remove();
+    this.triggerTarget.removeAttribute("aria-describedby");
+
+    this.mounted = null;
   }
 
   disconnect() {
-    this.cleanup();
+    this.unmount();
   }
 
-  setFloatingElement() {
-    this.cleanup = autoUpdate(this.triggerTarget, this.contentTarget, () => {
-      computePosition(this.triggerTarget, this.contentTarget, {
-        placement: this.placementValue,
-        middleware: [offset(4), shift()]
-      }).then(({ x, y }) => {
-        Object.assign(this.contentTarget.style, {
-          left: `${x}px`,
-          top: `${y}px`,
-        });
-      });
+  show() {
+    if (!this.hasContentTarget) return;
+
+    this.mount();
+    this.mounted.element.setAttribute("data-state", "open");
+  }
+
+  hide() {
+    this.mounted?.element.setAttribute("data-state", "closed");
+  }
+
+  animationEnd(event) {
+    if (event.animationName !== "exit") return;
+    if (this.mounted?.element.getAttribute("data-state") !== "closed") return;
+
+    this.unmount();
+  }
+
+  cloneTemplate() {
+    return this.contentTarget.content.firstElementChild.cloneNode(true);
+  }
+
+  reposition() {
+    if (!this.mounted) return;
+
+    const position = { placement: this.placementValue, middleware: [offset(4), shift()] };
+
+    computePosition(this.triggerTarget, this.mounted.element, position).then(({ x, y }) => {
+      this.mounted?.element.style.setProperty("left", `${x}px`);
+      this.mounted?.element.style.setProperty("top", `${y}px`);
     });
   }
 }

--- a/gem/lib/ruby_ui/tooltip/tooltip_trigger.rb
+++ b/gem/lib/ruby_ui/tooltip/tooltip_trigger.rb
@@ -12,7 +12,12 @@ module RubyUI
       {
         data: {
           ruby_ui__tooltip_target: "trigger",
-          action: "mouseenter->ruby-ui--tooltip#show mouseleave->ruby-ui--tooltip#hide focus->ruby-ui--tooltip#show blur->ruby-ui--tooltip#hide"
+          action: [
+            "mouseenter->ruby-ui--tooltip#show",
+            "mouseleave->ruby-ui--tooltip#hide",
+            "focus->ruby-ui--tooltip#show",
+            "blur->ruby-ui--tooltip#hide"
+          ]
         },
         variant: :outline
       }

--- a/gem/lib/ruby_ui/tooltip/tooltip_trigger.rb
+++ b/gem/lib/ruby_ui/tooltip/tooltip_trigger.rb
@@ -10,9 +10,11 @@ module RubyUI
 
     def default_attrs
       {
-        data: {ruby_ui__tooltip_target: "trigger"},
-        variant: :outline,
-        class: "peer"
+        data: {
+          ruby_ui__tooltip_target: "trigger",
+          action: "mouseenter->ruby-ui--tooltip#show mouseleave->ruby-ui--tooltip#hide focus->ruby-ui--tooltip#show blur->ruby-ui--tooltip#hide"
+        },
+        variant: :outline
       }
     end
   end


### PR DESCRIPTION
## Related issue
N/A — alignment with shadcn/ui defaults and behavior, following the **Preserving the shadcn look and feel** focus area in `CONTRIBUTING.md`.

## Description

Three issues with the current Tooltip, all fixed against shadcn's reference implementation:

### 1. No close animation

The current `peer-hover:visible` + `peer-hover:animate-in` pattern toggles visibility binarily — when the trigger is no longer hovered, the content's classes drop and the element snaps away with no exit animation playing.

Switched to the `data-state="open"|"closed"` pattern that shadcn/Radix use, with paired Tailwind variants:

```ruby
"data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95"
"data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=closed]:fill-mode-forwards"
```

`fill-mode-forwards` on the closed state is required because `tw-animate-css` defaults to `animation-fill-mode: none`. Without it, the `animate-out` keyframes play `opacity 1 → 0` and the element then snaps back to `opacity: 1`. With forwards, it stays at the final keyframe and is invisible until the next open.

### 2. Hardcoded 500ms delay

The current code applies `delay-500` unconditionally, which delays both open and close. shadcn overrides Radix's 700ms default with `delayDuration: 0` — the tooltip opens instantly when the cursor enters the trigger.

Removed `delay-500` entirely. Hover/focus now opens the tooltip immediately.

### 3. Eager rendering of every tooltip's HTML

Even when a page has 30 tooltips and the user never hovers any of them, each `TooltipContent` div is rendered into the active DOM and gets full CSS matching, layout, and Stimulus target scanning.

Now the content is wrapped in a `<template>` element. `<template>` children live in a `DocumentFragment` outside the active document tree — the browser does **not** apply CSS to them, does not compute layout, and Stimulus does not scan them for targets. On the first hover/focus, the controller clones the template's child into `document.body`, positions it with Floating UI, and toggles `data-state`. On the close animation's `animationend`, it unmounts (removes from body, stops `autoUpdate`).

### Other supporting changes

- Trigger now wires events through Stimulus actions (`mouseenter` / `mouseleave` / `focus` / `blur` on a single `data-action`) instead of CSS sibling selectors. This also lets the cloned content live outside the trigger's subtree (in `body`), avoiding clipping by `overflow: hidden` ancestors.
- `class: \"peer\"` removed from the trigger — the sibling-selector pattern is gone.
- `turbo:before-cache` listener unmounts the tooltip before Turbo snapshots the page, keeping cached snapshots clean (a tooltip in `body` would otherwise be orphaned from its controller on cache restore).
- `pointer-events-none` on the content base — the cloned element stays in the layout at `opacity: 0` after close (because of `fill-mode-forwards`), so it shouldn't capture the cursor.

## Testing instructions

1. Hover any tooltip trigger → tooltip appears instantly with `fade-in` + `zoom-in` + `slide-in` (no 500ms wait).
2. Leave the trigger → tooltip plays `fade-out` + `zoom-out` and disappears.
3. Hover quickly in/out/in → the close animation is interrupted by the open, no flicker.
4. Inspect DOM before hovering: no `tooltip-content-*` element exists in `body`.
5. Inspect DOM after hovering and leaving: `tooltip-content-*` is removed from `body` once the exit animation ends.
6. Navigate to another page and back (Turbo cache) → tooltip still works.
7. `cd gem && bundle exec rake` → tests + standardrb pass (existing assertions on `w-fit`, `max-w-[calc(100vw-2rem)]`, `break-words` are preserved).