### PR TITLE
[Feature] Add Sheet initial open state

### DIFF
--- a/gem/lib/ruby_ui/sheet/sheet.rb
+++ b/gem/lib/ruby_ui/sheet/sheet.rb
@@ -2,6 +2,11 @@
 
 module RubyUI
   class Sheet < Base
+    def initialize(open: false, **attrs)
+      @open = open
+      super(**attrs)
+    end
+
     def view_template(&)
       div(**attrs, &)
     end
@@ -10,7 +15,10 @@ module RubyUI
 
     def default_attrs
       {
-        data: {controller: "ruby-ui--sheet"}
+        data: {
+          controller: "ruby-ui--sheet",
+          ruby_ui__sheet_open_value: @open.to_s
+        }
       }
     end
   end

--- a/gem/lib/ruby_ui/sheet/sheet_controller.js
+++ b/gem/lib/ruby_ui/sheet/sheet_controller.js
@@ -3,6 +3,12 @@ import { Controller } from "@hotwired/stimulus"
 export default class extends Controller {
   static targets = ["content"]
 
+  static values = { open: false }
+
+  connect() {
+    if (this.openValue) this.open()
+  }
+
   open() {
     document.body.insertAdjacentHTML("beforeend", this.contentTarget.innerHTML)
   }

--- a/gem/test/ruby_ui/sheet_test.rb
+++ b/gem/test/ruby_ui/sheet_test.rb
@@ -30,4 +30,16 @@ class RubyUI::SheetTest < ComponentTest
 
     assert_match(/Open Sheet/, output)
   end
+
+  def test_render_closed_by_default
+    output = phlex { RubyUI.Sheet { "content" } }
+
+    assert_match(/data-ruby-ui--sheet-open-value="false"/, output)
+  end
+
+  def test_render_open_when_open_is_true
+    output = phlex { RubyUI.Sheet(open: true) { "content" } }
+
+    assert_match(/data-ruby-ui--sheet-open-value="true"/, output)
+  end
 end


### PR DESCRIPTION
## Summary

Adds an `open:` keyword to `RubyUI::Sheet` so a Sheet can render already open on the initial response — no `SheetTrigger` click required.

```ruby
Sheet(open: true) do
  SheetContent(class: "sm:max-w-sm") do
    # ...
  end
end
```

## Why

When a Sheet is rendered as the result of a Turbo Stream (or any server-driven render where the user did not click a trigger), there is no `SheetTrigger` in scope to open it. Today the only way to surface the Sheet is to dispatch the controller's `open` action manually from JS.

Use case: clicking a table row dispatches a `GET` accepting `text/vnd.turbo-stream.html`; the response targets a `turbo_frame_tag` in the layout with `turbo_stream.update("FRAME_ID", Sheet(open: true) { ... })`. The Sheet appears as soon as the stream lands.

## Implementation

- `RubyUI::Sheet#initialize` now accepts `open: false` and forwards remaining `**attrs` to `super`.
- `default_attrs` exposes the value to Stimulus via `data-ruby-ui--sheet-open-value`.
- `sheet_controller.js` declares `static values = { open: false }` and calls `this.open()` on `connect()` when `openValue` is true.
- Defaults to `false`, so existing usage is unchanged.

## Tests

- `test_render_closed_by_default` — confirms the data attribute defaults to `"false"`.
- `test_render_open_when_open_is_true` — confirms `Sheet(open: true)` emits `data-ruby-ui--sheet-open-value="true"`.

Existing test (`test_render_with_all_items`) still passes — additive change only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an `open:` option to `RubyUI::Sheet` to render a Sheet already open on the initial response. Enables Turbo Stream/server-driven renders to show the Sheet without a `SheetTrigger`; defaults to closed for backward compatibility.

- **New Features**
  - Add `open:` to `RubyUI::Sheet`, exposing `data-ruby-ui--sheet-open-value` for Stimulus.
  - Controller reads `openValue` and calls `open()` on connect when true.
  - Works with Turbo Stream updates; no manual JS dispatch needed.

<sup>Written for commit 3aad267a96b8745aa7894f3eb7513506e28b886f. Summary will update on new commits. <a href="https://cubic.dev/pr/ruby-ui/ruby_ui/pull/402?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

