### PR TITLE
[Bug Fix] Rename devcontainer image to repo-owned ghcr package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,7 @@ jobs:
       - name: Build and push devcontainer image
         uses: devcontainers/ci@v0.3
         with:
-          imageName: ghcr.io/ruby-ui/web-devcontainer
-          cacheFrom: ghcr.io/ruby-ui/web-devcontainer
+          imageName: ghcr.io/ruby-ui/ruby_ui-devcontainer
+          cacheFrom: ghcr.io/ruby-ui/ruby_ui-devcontainer
           subFolder: docs
           push: always


### PR DESCRIPTION
## Problem

The **Docker build (Devcontainer)** job is red on every `main` run since the monorepo unification (#358) — it has never passed:

```
denied: permission_denied: write_package
##[error]Error: push failed with 1
```

The build itself succeeds; the push to `ghcr.io/ruby-ui/web-devcontainer` is denied. That package was created by the (now archived) `ruby-ui/web` repo, which retains exclusive write access — this repo's `GITHUB_TOKEN` can't push to it despite `packages: write`.

## Fix

Rename the image to `ghcr.io/ruby-ui/ruby_ui-devcontainer`. The first push from this repo auto-creates the package linked here with write access.

Safe because the image is only a CI artifact/build cache — `docs/.devcontainer/devcontainer.json` builds from the local Dockerfile; nothing pulls the old name (only references are in `ci.yml` itself). First run will miss `cacheFrom` (slower build once), then cache normally.

Alternative considered: granting this repo write access on the old package via org package settings — requires org admin UI action and keeps a stale name (`web-`) from the pre-monorepo repo.

## Test steps

- Job is main-only (`if: github.ref == 'refs/heads/main'`), so it skips on this PR.
- After merge, the next main run's **Docker build (Devcontainer)** job should go green and `ghcr.io/ruby-ui/ruby_ui-devcontainer:latest` should appear in org packages.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the failing Devcontainer build on main by renaming the GHCR image to a repo-owned package. Pushes now go to `ghcr.io/ruby-ui/ruby_ui-devcontainer`, so the workflow can create and push the image.

- **Bug Fixes**
  - Updated `imageName` and `cacheFrom` in `.github/workflows/ci.yml` to `ghcr.io/ruby-ui/ruby_ui-devcontainer`.
  - Only affects the CI build cache; first run may be slower due to a cold cache.

<sup>Written for commit 980ad6b42d929698bc09091b97de7f52f7927c5a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruby-ui/ruby_ui/pull/413?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

