### PR TITLE
[Release] v1.3.0

### DIFF
--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -15,7 +15,7 @@ GIT
 PATH
   remote: ../gem
   specs:
-    ruby_ui (1.2.0)
+    ruby_ui (1.3.0)
 
 PATH
   remote: ../mcp

--- a/docs/app/views/pages/home.rb
+++ b/docs/app/views/pages/home.rb
@@ -7,7 +7,7 @@ class Views::Pages::Home < Views::Base
       div(class: "container flex max-w-[64rem] flex-col items-center gap-4 text-center mx-auto") do
         Link(href: docs_changelog_path, variant: :outline, class: "rounded-2xl px-4 py-1.5 text-sm font-medium") do
           span(class: "sm:hidden") { "New components available" }
-          span(class: "hidden sm:inline") { "Combobox updates and more" }
+          span(class: "hidden sm:inline") { "Datatable, Toast, and more" }
           svg(xmlns: "http://www.w3.org/2000/svg", width: "24", height: "24", viewbox: "0 0 24 24", fill: "none", stroke: "currentColor", stroke_width: "2", stroke_linecap: "round", stroke_linejoin: "round", class: "ml-2 h-4 w-4") { |s|
             s.path(d: "M5 12h14")
             s.path(d: "m12 5 7 7-7 7")

--- a/gem/Gemfile.lock
+++ b/gem/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ruby_ui (1.2.0)
+    ruby_ui (1.3.0)
 
 GEM
   remote: https://rubygems.org/

--- a/gem/lib/generators/ruby_ui/dependencies.yml
+++ b/gem/lib/generators/ruby_ui/dependencies.yml
@@ -2,16 +2,6 @@ accordion:
   js_packages:
     - "motion"
 
-data_table:
-  components:
-    - "Table"
-    - "Checkbox"
-    - "NativeSelect"
-    - "Pagination"
-    - "DropdownMenu"
-    - "Input"
-    - "Button"
-
 alert_dialog:
   components:
     - "Button"

--- a/gem/lib/ruby_ui.rb
+++ b/gem/lib/ruby_ui.rb
@@ -3,5 +3,5 @@
 require "date"
 
 module RubyUI
-  VERSION = "1.2.0"
+  VERSION = "1.3.0"
 end

--- a/mcp/data/registry.json
+++ b/mcp/data/registry.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.2.0",
+  "version": "1.3.0",
   "components": {
     "accordion": {
       "name": "Accordion",


### PR DESCRIPTION
## Release 1.3.0

Resolves #408 — released 1.2.0 (Apr 29) predates Toast (#389), so `rails g ruby_ui:component Toast` fails on the installed gem. Verified on a fresh Rails 8.1 app against main: both `Toast` (9 components + 2 Stimulus controllers) and `DataTable` (17 components + 3 controllers + 7 dependency components) generate cleanly.

### Changes
- `RubyUI::VERSION` → 1.3.0 (+ both lockfiles regenerated)
- Home hero badge: "Combobox updates and more" → "Datatable, Toast, and more"
- Header version badge is dynamic (`logo.rb` renders `RubyUI::VERSION`) — no edit needed
- Dedupe `data_table:` key in `dependencies.yml` (duplicate identical entries; YAML last-key-wins so no behavior change)

### After merge
- Tag `v1.3.0` + GitHub release (changelog page feeds off the releases atom feed)
- `gem build && gem push` to RubyGems from `gem/`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release v1.3.0 to ship Toast and DataTable generators and fix the `rails g ruby_ui:component Toast` failure in 1.2.0 (fixes #408).
Also updates the docs hero text, removes the duplicate `data_table` entry in `dependencies.yml`, bumps `RubyUI::VERSION`, regenerates lockfiles, and rebuilds the MCP registry for 1.3.0.

<sup>Written for commit 2ace7f5b6acd863181637dae4cc21570a46f6a05. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruby-ui/ruby_ui/pull/414?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

