### PR TITLE
[Feature] Allow ruby_ui:component to accept multiple components

### DIFF
--- a/gem/README.md
+++ b/gem/README.md
@@ -55,6 +55,12 @@ You can generate your components using `ruby_ui:component` generator.
 bin/rails g ruby_ui:component Accordion
 ```
 
+You can also generate multiple components at once.
+
+```bash
+bin/rails g ruby_ui:component Button Link Input Textarea
+```
+
 You also can generate all components using `ruby_ui:component:all` generator
 
 ## Documentation 📖

--- a/gem/lib/generators/ruby_ui/component/all_generator.rb
+++ b/gem/lib/generators/ruby_ui/component/all_generator.rb
@@ -10,7 +10,11 @@ module RubyUI
         def generate_components
           say "Generating all components..."
 
-          folder_names = Dir.children(self.class.source_root).reject { |folder_name| folder_name.ends_with?(".rb") }
+          # Each component lives in its own directory; select directories only so stray
+          # files (e.g. base.rb or a macOS .DS_Store) are never passed as component names.
+          folder_names = Dir.children(self.class.source_root).select do |entry|
+            File.directory?(File.join(self.class.source_root, entry))
+          end
 
           run "bin/rails generate ruby_ui:component #{folder_names.join(" ")} --force #{options["force"]}"
         end

--- a/gem/lib/generators/ruby_ui/component/all_generator.rb
+++ b/gem/lib/generators/ruby_ui/component/all_generator.rb
@@ -10,11 +10,9 @@ module RubyUI
         def generate_components
           say "Generating all components..."
 
-          Dir.children(self.class.source_root).each do |folder_name|
-            next if folder_name.ends_with?(".rb")
+          folder_names = Dir.children(self.class.source_root).reject { |folder_name| folder_name.ends_with?(".rb") }
 
-            run "bin/rails generate ruby_ui:component #{folder_name} --force #{options["force"]}"
-          end
+          run "bin/rails generate ruby_ui:component #{folder_names.join(" ")} --force #{options["force"]}"
         end
       end
     end

--- a/gem/lib/generators/ruby_ui/component_generator.rb
+++ b/gem/lib/generators/ruby_ui/component_generator.rb
@@ -7,69 +7,89 @@ module RubyUI
       namespace "ruby_ui:component"
 
       source_root File.expand_path("../../ruby_ui", __dir__)
-      argument :component_name, type: :string, required: true
+      argument :component_names, type: :array, required: true, banner: "Button Link Input"
       class_option :force, type: :boolean, default: false
       class_option :with_docs, type: :boolean, default: false
 
-      def generate_component
-        if component_not_found?
-          say "Component not found: #{component_name}", :red
-          exit
+      def generate_components
+        validate_components!
+
+        component_names.each do |component_name|
+          say "Generating #{component_name} files..."
+          copy_related_component_files(component_name)
+          copy_js_files(component_name)
+          install_dependencies(component_name)
         end
 
-        say "Generating #{component_name} files..."
-      end
-
-      def copy_related_component_files
-        say "Generating components"
-
-        components_file_paths.each do |file_path|
-          component_file_name = file_path.split("/").last
-          copy_file file_path, Rails.root.join("app/components/ruby_ui", component_folder_name, component_file_name), force: options["force"]
-        end
-      end
-
-      def copy_js_files
-        return if js_controller_file_paths.empty?
-
-        say "Generating Stimulus controllers"
-
-        js_controller_file_paths.each do |file_path|
-          controller_file_name = file_path.split("/").last
-          copy_file file_path, Rails.root.join("app/javascript/controllers/ruby_ui", controller_file_name), force: options["force"]
-        end
-
-        # Importmap doesn't have controller manifest, instead it uses `eagerLoadControllersFrom("controllers", application)`
-        if !using_importmap?
-          say "Updating Stimulus controllers manifest"
-          run "rake stimulus:manifest:update"
-        end
-      end
-
-      def install_dependencies
-        return if dependencies.blank?
-
-        say "Installing dependencies"
-
-        install_components_dependencies(dependencies["components"])
-        install_gems_dependencies(dependencies["gems"])
-        install_js_packages(dependencies["js_packages"])
+        update_stimulus_manifest
       end
 
       private
 
-      def component_not_found? = !Dir.exist?(component_folder_path)
+      def validate_components!
+        missing = component_names.reject { |name| component_exists?(name) }
+        return if missing.empty?
 
-      def component_folder_name = component_name.underscore
+        say "Component(s) not found: #{missing.join(", ")}", :red
+        exit
+      end
 
-      def component_folder_path = File.join(self.class.source_root, component_folder_name)
+      def copy_related_component_files(component_name)
+        say "Generating components"
 
-      def components_file_paths
-        files = Dir.glob(File.join(component_folder_path, "*.rb"))
+        components_file_paths(component_name).each do |file_path|
+          component_file_name = file_path.split("/").last
+          copy_file file_path, Rails.root.join("app/components/ruby_ui", component_folder_name(component_name), component_file_name), force: options["force"]
+        end
+      end
+
+      def copy_js_files(component_name)
+        paths = js_controller_file_paths(component_name)
+        return if paths.empty?
+
+        say "Generating Stimulus controllers"
+
+        paths.each do |file_path|
+          controller_file_name = file_path.split("/").last
+          copy_file file_path, Rails.root.join("app/javascript/controllers/ruby_ui", controller_file_name), force: options["force"]
+        end
+
+        @stimulus_controllers_added = true
+      end
+
+      def update_stimulus_manifest
+        return unless @stimulus_controllers_added
+
+        # Importmap doesn't have controller manifest, instead it uses `eagerLoadControllersFrom("controllers", application)`
+        return if using_importmap?
+
+        say "Updating Stimulus controllers manifest"
+        run "rake stimulus:manifest:update"
+      end
+
+      def install_dependencies(component_name)
+        deps = dependencies(component_name)
+        return if deps.blank?
+
+        say "Installing dependencies"
+
+        install_components_dependencies(deps["components"])
+        install_gems_dependencies(deps["gems"])
+        install_js_packages(deps["js_packages"])
+      end
+
+      def component_exists?(component_name) = Dir.exist?(component_folder_path(component_name))
+
+      def component_folder_name(component_name) = component_name.underscore
+
+      def component_folder_path(component_name) = File.join(self.class.source_root, component_folder_name(component_name))
+
+      def components_file_paths(component_name)
+        files = Dir.glob(File.join(component_folder_path(component_name), "*.rb"))
         options["with_docs"] ? files : files.reject { |f| f.end_with?("_docs.rb") }
       end
 
-      def js_controller_file_paths = Dir.glob(File.join(component_folder_path, "*.js"))
+      def js_controller_file_paths(component_name) = Dir.glob(File.join(component_folder_path(component_name), "*.js"))
 
       def install_components_dependencies(components)
         components&.each do |component|
@@ -89,10 +109,10 @@ module RubyUI
         end
       end
 
-      def dependencies
+      def dependencies(component_name)
         @dependencies ||= YAML.load_file(File.join(__dir__, "dependencies.yml")).freeze
 
-        @dependencies[component_folder_name]
+        @dependencies[component_folder_name(component_name)]
       end
     end
   end

--- a/gem/lib/generators/ruby_ui/component_generator.rb
+++ b/gem/lib/generators/ruby_ui/component_generator.rb
@@ -31,7 +31,7 @@ module RubyUI
         return if missing.empty?
 
         say "Component(s) not found: #{missing.join(", ")}", :red
-        exit
+        exit 1
       end
 
       def copy_related_component_files(component_name)

--- a/gem/test/generators/component_generator_test.rb
+++ b/gem/test/generators/component_generator_test.rb
@@ -82,4 +82,25 @@ class ComponentGeneratorTest < Minitest::Test
 
     assert_includes dependencies.fetch("tooltip").fetch("components"), "Typography"
   end
+
+  def test_resolves_component_folders_for_multiple_components
+    source_root = File.expand_path("../../lib/ruby_ui", __dir__)
+
+    # Folder names mirror ComponentGenerator's `component_name.underscore`.
+    {"Button" => "button", "Link" => "link", "Input" => "input", "Textarea" => "textarea"}.each do |component_name, folder_name|
+      folder_path = File.join(source_root, folder_name)
+
+      assert(Dir.exist?(folder_path),
+        "Expected folder for #{component_name} to exist at #{folder_path}")
+    end
+  end
+
+  def test_validation_collects_all_missing_components
+    source_root = File.expand_path("../../lib/ruby_ui", __dir__)
+    folder_names = {"Button" => "button", "NotARealComponent" => "not_a_real_component", "AnotherFakeOne" => "another_fake_one"}
+
+    missing = folder_names.reject { |_name, folder| Dir.exist?(File.join(source_root, folder)) }.keys
+
+    assert_equal %w[NotARealComponent AnotherFakeOne], missing
+  end
 end


### PR DESCRIPTION
## Description

The `ruby_ui:component` generator previously accepted only a single component name. This PR allows multiple component names to be passed in a single invocation:

```bash
bin/rails g ruby_ui:component Button Link Input Textarea
```

This also aligns the generator with the command already produced by the MCP add-command tool (`get_add_command_for_items`), which was already joining multiple component names into a single `rails g ruby_ui:component ...` command.

## Changes

- Switch the generator argument from a single string to an array, keeping single-component usage fully backward compatible.
- Validate all component names upfront and report every missing component at once (instead of aborting on the first).
- Run the Stimulus controllers manifest update a single time at the end, instead of once per component.
- `ruby_ui:component:all` now delegates to a single generator invocation with all component folders, avoiding one Rails boot per component.
- Add tests and a README example.

## Result

```
➜  testappconverter git:(main) ✗ bin/rails g ruby_ui:component Button Link Input Textarea
Generating Button files...
Generating components
      create  app/components/ruby_ui/button/button.rb
Generating Link files...
Generating components
      create  app/components/ruby_ui/link/link.rb
Generating Input files...
Generating components
      create  app/components/ruby_ui/input/input.rb
Generating Textarea files...
Generating components
      create  app/components/ruby_ui/textarea/textarea.rb

➜  testappconverter git:(main) ✗ bin/rails g ruby_ui:component Button Link Input Textarea
Generating Button files...
Generating components
   identical  app/components/ruby_ui/button/button.rb
Generating Link files...
Generating components
   identical  app/components/ruby_ui/link/link.rb
Generating Input files...
Generating components
   identical  app/components/ruby_ui/input/input.rb
Generating Textarea files...
Generating components
   identical  app/components/ruby_ui/textarea/textarea.rb
```

## Testing steps

```bash
cd gem
bundle exec rake   # tests + standardrb
```

Both the full test suite (217 runs, 0 failures) and StandardRB (364 files, no offenses) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add multi-component support to the `ruby_ui:component` generator to speed up bulk generation and align with the MCP add-command output.

- **New Features**
  - Accept multiple component names in one command (e.g., `bin/rails g ruby_ui:component Button Link Input Textarea`). Backward compatible with single-name usage.
  - Validate all names upfront, report all missing together, and exit with status 1 if any are missing.
  - Update the Stimulus controllers manifest once after all copies.
  - Make `ruby_ui:component:all` call a single generator run with all folders to avoid repeated Rails boots.
  - Add tests and a README example.

- **Bug Fixes**
  - `ruby_ui:component:all` now selects directories only, ignoring stray files (e.g., `.DS_Store`) to prevent batch aborts during validation.

<sup>Written for commit 11cf1726551d742e63b516234e976f0b7f83c12c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruby-ui/ruby_ui/pull/416?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



