### PR TITLE
[Bug Fix] Fix gem linter: remove redundant keyword_init: true

### DIFF
--- a/docs/app/components/themes/grid/repo_tabs.rb
+++ b/docs/app/components/themes/grid/repo_tabs.rb
@@ -4,7 +4,7 @@ module Components
   module Themes
     module Grid
       class RepoTabs < Components::Base
-        Repo = Struct.new(:github_url, :name, :stars, :version, keyword_init: true)
+        Repo = Struct.new(:github_url, :name, :stars, :version)
 
         def view_template
           Tabs(default_value: "overview", class: "w-full") do

--- a/docs/app/components/themes/grid/table.rb
+++ b/docs/app/components/themes/grid/table.rb
@@ -4,7 +4,7 @@ module Components
   module Themes
     module Grid
       class Table < Components::Base
-        User = Struct.new(:avatar_url, :name, :username, :commits, :github_url, keyword_init: true)
+        User = Struct.new(:avatar_url, :name, :username, :commits, :github_url)
 
         # def view_template
         #   render RubyUI::Card.new(class: "p-6") do

--- a/docs/app/views/docs/data_table.rb
+++ b/docs/app/views/docs/data_table.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Views::Docs::DataTable < Views::Base
-  Row = Struct.new(:id, :name, :email, :salary, :status, keyword_init: true)
+  Row = Struct.new(:id, :name, :email, :salary, :status)
 
   def view_template
     @rows = [

--- a/docs/app/views/docs/table.rb
+++ b/docs/app/views/docs/table.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class Views::Docs::Table < Views::Base
-  Invoice = Struct.new(:identifier, :status, :method, :amount, keyword_init: true)
-  User = Struct.new(:avatar_url, :name, :username, :commits, :github_url, keyword_init: true)
+  Invoice = Struct.new(:identifier, :status, :method, :amount)
+  User = Struct.new(:avatar_url, :name, :username, :commits, :github_url)
 
   def view_template
     component = "Table"

--- a/docs/app/views/docs/tabs.rb
+++ b/docs/app/views/docs/tabs.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Views::Docs::Tabs < Views::Base
-  Repo = Struct.new(:github_url, :name, :stars, :version, keyword_init: true)
+  Repo = Struct.new(:github_url, :name, :stars, :version)
 
   def view_template
     component = "Tabs"

--- a/gem/lib/ruby_ui/data_table/data_table_docs.rb
+++ b/gem/lib/ruby_ui/data_table/data_table_docs.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Views::Docs::DataTable < Views::Base
-  Row = Struct.new(:id, :name, :email, :salary, :status, keyword_init: true)
+  Row = Struct.new(:id, :name, :email, :salary, :status)
 
   SAMPLE_ROWS = [
     Row.new(id: 1, name: "Alice", email: "alice@example.com", salary: 90_000, status: "Active"),

--- a/gem/lib/ruby_ui/table/table_docs.rb
+++ b/gem/lib/ruby_ui/table/table_docs.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class Views::Docs::Table < Views::Base
-  Invoice = Struct.new(:identifier, :status, :method, :amount, keyword_init: true)
-  User = Struct.new(:avatar_url, :name, :username, :commits, :github_url, keyword_init: true)
+  Invoice = Struct.new(:identifier, :status, :method, :amount)
+  User = Struct.new(:avatar_url, :name, :username, :commits, :github_url)
 
   def view_template
     component = "Table"

--- a/gem/lib/ruby_ui/tabs/tabs_docs.rb
+++ b/gem/lib/ruby_ui/tabs/tabs_docs.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Views::Docs::Tabs < Views::Base
-  Repo = Struct.new(:github_url, :name, :stars, :version, keyword_init: true)
+  Repo = Struct.new(:github_url, :name, :stars, :version)
 
   def view_template
     component = "Tabs"


### PR DESCRIPTION
## Description

The gem linter (`rake standard`) is currently failing on `main`, independent of any feature work. Standard now flags `Style/RedundantStructKeywordInit`: on Ruby 3.2+ a `Struct` accepts both positional and keyword arguments, so `keyword_init: true` is redundant.

Four offenses across three docs Structs:

- `lib/ruby_ui/data_table/data_table_docs.rb:4`
- `lib/ruby_ui/table/table_docs.rb:4` and `:5`
- `lib/ruby_ui/tabs/tabs_docs.rb:4`

This PR removes the redundant `keyword_init: true`. The structs are still instantiated with keyword arguments throughout the docs, which keeps working on the gem's supported Ruby (`>= 3.2`).

The cop's autocorrect is marked unsafe (it would change behavior on Ruby < 3.2), so `standardrb --fix` leaves it alone — hence the manual edit.

## How to test

```bash
cd gem
bundle exec rake standard   # 364 files inspected, no offenses detected
bundle exec rake test       # all green
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes failing linters in both the gem and the docs app by removing redundant `keyword_init: true` from sample `Struct`s. Ruby 3.2+ accepts keyword args without it, so behavior is unchanged and both linters pass.

- **Bug Fixes**
  - Removed `keyword_init: true` from `Row`, `Invoice`, `User`, and `Repo` across gem `*_docs.rb` and docs app components/views.
  - Confirmed keyword instantiation on Ruby >= 3.2; gem and docs linters green, gem tests pass.

<sup>Written for commit d71f26a3a58819c8f976ab1a003c441cb429161f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruby-ui/ruby_ui/pull/426?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

