### PR TITLE
[Bug Fix] Fix /docs/dropdown_menu 404 (#428)

### DIFF
--- a/docs/app/views/docs/dropdown_menu.rb
+++ b/docs/app/views/docs/dropdown_menu.rb
@@ -43,7 +43,7 @@ class Views::Docs::DropdownMenu < Views::Base
                       DialogDescription { "This action cannot be undone." }
                     end
                     DialogFooter do
-                      DialogClose { Button(variant: :destructive) { "Delete" } }
+                      Button(variant: :destructive, data: { action: 'click->ruby-ui--dialog#dismiss' }) { "Delete" }
                     end
                   end
                 end

--- a/docs/config/application.rb
+++ b/docs/config/application.rb
@@ -24,6 +24,9 @@ module RubyUiWeb
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
 
-    config.exceptions_app = ->(env) { ErrorsController.action(:not_found).call(env) }
+    # Dispatch exceptions through the router (see the /404 and /500 routes) so the
+    # response status matches the actual error. A bare lambda to a single action
+    # rendered every failure as 404, masking 500s (e.g. a raising view) as "not found".
+    config.exceptions_app = routes
   end
 end


### PR DESCRIPTION
Fixes #428 — `/docs/dropdown_menu` returned a 404.

## Root cause
Two stacked problems:

1. **Broken docs example.** The "Non-navigational item" example added in #427 referenced a `DialogClose` component that does not exist in the gem. `VisualCodeExample` evaluates the snippet at render time (`instance_eval`), so it raised `NoMethodError: undefined method 'DialogClose'` and the page failed to render.
2. **Error masking.** `config.exceptions_app` was a lambda that always rendered the `not_found` action, so the resulting 500 surfaced as a **404** page — hiding the real error and making the issue look like a missing route.

## Changes
- **`docs/app/views/docs/dropdown_menu.rb`** — close the dialog with the documented pattern (`Button` wired to `click->ruby-ui--dialog#dismiss`, the same approach used in `dialog_docs.rb`) instead of the nonexistent `DialogClose`.
- **`docs/config/application.rb`** — point `exceptions_app` at the router. The `/404` and `/500` routes already exist, so the response status now matches the actual error and `ErrorsController#internal_server_error` becomes reachable. This un-masks future 500s.

## Verification
- Live (docker): `/docs/dropdown_menu` → **200**, renders clean. Exercised the example in-browser — dropdown opens, "Delete" item opens the Dialog, the Delete button dismisses it.
- `bin/rails test` → 70 runs, 0 failures. `standardrb` clean.

## Note on search (⌘K)
Investigated the reported search issue too: **production search works** (verified in-browser — click opens the command dialog and focuses the input). The local breakage was a stale, gitignored asset build predating the `command-dialog` controller; rebuilding assets fixes it. No code change needed, so nothing for it here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the /docs/dropdown_menu 404 by correcting the docs example and routing exceptions through the Rails router so real 500s aren’t masked as 404s.

- **Bug Fixes**
  - Replaced nonexistent `DialogClose` in the “Non‑navigational item” example with a `Button` wired to `click->ruby-ui--dialog#dismiss`.
  - Set `config.exceptions_app = routes` so `/404` and `/500` handle errors and status codes reflect the actual failure.

<sup>Written for commit 6b79055d2b786a460f5e895bf4f6ddacbbaf9563. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruby-ui/ruby_ui/pull/429?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

