### PR TITLE
[Bug Fix] Avatar: lazy-loaded image never appears (stuck on fallback) (#415)

### DIFF
--- a/gem/lib/ruby_ui/avatar/avatar_image.rb
+++ b/gem/lib/ruby_ui/avatar/avatar_image.rb
@@ -16,7 +16,11 @@ module RubyUI
 
     def default_attrs
       {
-        loading: "lazy",
+        # NB: do not set loading: "lazy" here. avatar_controller hides a not-yet-loaded
+        # image with `display:none` (the `hidden` class) so the fallback shows. The
+        # browser never fetches a `loading="lazy"` image that generates no box, so its
+        # `load` event never fires and the image stays hidden forever (#415). shadcn/radix
+        # do not lazy-load the avatar image either.
         data: {
           ruby_ui__avatar_target: "image",
           action: "load->ruby-ui--avatar#showImage error->ruby-ui--avatar#showFallback"

--- a/gem/test/ruby_ui/avatar_test.rb
+++ b/gem/test/ruby_ui/avatar_test.rb
@@ -19,4 +19,18 @@ class RubyUI::AvatarTest < ComponentTest
     assert_match(/class="aspect-square h-full w-full"/, output)
     refute_match(/class="[^"]*\bhidden\b[^"]*aspect-square/, output)
   end
+
+  def test_image_is_not_lazy_loaded
+    # Regression for #415: the controller hides a still-loading image with
+    # display:none, and a loading="lazy" image with no box is never fetched, so
+    # it would stay hidden forever. The avatar image must load eagerly.
+    output = phlex do
+      RubyUI.Avatar do
+        RubyUI.AvatarImage(src: "https://avatars.githubusercontent.com/u/246692?v=4", alt: "joeldrapper")
+        RubyUI.AvatarFallback { "JD" }
+      end
+    end
+
+    refute_match(/loading="lazy"/, output)
+  end
 end

--- a/mcp/data/registry.json
+++ b/mcp/data/registry.json
@@ -226,7 +226,7 @@
         },
         {
           "path": "avatar_image.rb",
-          "content": "# frozen_string_literal: true\n\nmodule RubyUI\n  class AvatarImage < Base\n    def initialize(src:, alt: \"\", **attrs)\n      @src = src\n      @alt = alt\n      super(**attrs)\n    end\n\n    def view_template\n      img(**attrs)\n    end\n\n    private\n\n    def default_attrs\n      {\n        loading: \"lazy\",\n        data: {\n          ruby_ui__avatar_target: \"image\",\n          action: \"load->ruby-ui--avatar#showImage error->ruby-ui--avatar#showFallback\"\n        },\n        class: \"aspect-square h-full w-full\",\n        alt: @alt,\n        src: @src\n      }\n    end\n  end\nend\n"
+          "content": "# frozen_string_literal: true\n\nmodule RubyUI\n  class AvatarImage < Base\n    def initialize(src:, alt: \"\", **attrs)\n      @src = src\n      @alt = alt\n      super(**attrs)\n    end\n\n    def view_template\n      img(**attrs)\n    end\n\n    private\n\n    def default_attrs\n      {\n        # NB: do not set loading: \"lazy\" here. avatar_controller hides a not-yet-loaded\n        # image with `display:none` (the `hidden` class) so the fallback shows. The\n        # browser never fetches a `loading=\"lazy\"` image that generates no box, so its\n        # `load` event never fires and the image stays hidden forever (#415). shadcn/radix\n        # do not lazy-load the avatar image either.\n        data: {\n          ruby_ui__avatar_target: \"image\",\n          action: \"load->ruby-ui--avatar#showImage error->ruby-ui--avatar#showFallback\"\n        },\n        class: \"aspect-square h-full w-full\",\n        alt: @alt,\n        src: @src\n      }\n    end\n  end\nend\n"
         }
       ],
       "dependencies": {


### PR DESCRIPTION
Fixes #415.

## Problem
An uncached `AvatarImage` can get permanently stuck on the fallback and never appear.

`avatar_controller.js` hides a still-loading image with `display:none` (the `hidden` class) so the fallback shows while the image loads:

```js
if (this.imageTarget.complete && this.imageTarget.naturalWidth > 0) {
  this.showImage();
} else {
  this.showFallback(); // adds `hidden` -> display:none on the <img>
}
```

But `avatar_image.rb` rendered the image with `loading="lazy"`. Browsers do **not** fetch a `loading="lazy"` image whose box is not generated (`display:none`), so the `load` event never fires and `showImage()` is never called — the image stays hidden indefinitely. Cached images are unaffected because they are already `complete` at `connect()`.

This is a self-contradiction: `loading="lazy"` defers loading until the element is visible, while `connect()` makes the element invisible before it has loaded.

## Fix
Remove `loading="lazy"` from `AvatarImage`. The image now loads eagerly even while hidden, so the `load`/`error` handlers reliably reveal it (and the fallback is shown while loading, exactly as intended). This matches **shadcn/radix**, which do not lazy-load the avatar image.

Minimal change, no JS or markup restructure.

## Verification
Reproduced in a browser harness with cache-busting URLs and a delayed image server:
- **Before** (`lazy` + hide): image request is never made; fallback shows forever.
- **After** (eager + hide): fallback shows during load, then the image appears on `load`; on `error` the fallback remains.

Tests: added a regression test asserting the rendered image is not `loading="lazy"`. `bundle exec rake` (test + standardrb) green — 223 runs, 0 failures; 366 files, no offenses.

## Notes
- Alternatives considered (and rejected as more invasive / less reliable): only hiding on definitive failure (leaves an empty box instead of the fallback during load), or hiding via `opacity`/`visibility` + absolute overlay to keep `lazy` (CSS-hidden + lazy load behavior is browser-dependent). Dropping `lazy` is the simplest fix and aligns with shadcn/radix.
- No docs example change needed — behavior-only fix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop lazy-loading the avatar image so it loads while hidden and no longer gets stuck on the fallback. Fixes #415.

- **Bug Fixes**
  - Removed `loading="lazy"` from `AvatarImage`; rebuilt MCP registry.
  - Ensures `load`/`error` handlers run and the image replaces the fallback; added a regression test that it's not lazy-loaded.

<sup>Written for commit 2253f17c96dfb878025827edbf8319ab59ba9132. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruby-ui/ruby_ui/pull/430?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

