### PR TITLE
[Release] v1.4.0

### DIFF
--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -15,7 +15,7 @@ GIT
 PATH
   remote: ../gem
   specs:
-    ruby_ui (1.3.0)
+    ruby_ui (1.4.0)
 
 PATH
   remote: ../mcp

--- a/docs/app/views/pages/home.rb
+++ b/docs/app/views/pages/home.rb
@@ -7,7 +7,7 @@ class Views::Pages::Home < Views::Base
       div(class: "container flex max-w-[64rem] flex-col items-center gap-4 text-center mx-auto") do
         Link(href: docs_changelog_path, variant: :outline, class: "rounded-2xl px-4 py-1.5 text-sm font-medium") do
           span(class: "sm:hidden") { "New components available" }
-          span(class: "hidden sm:inline") { "Datatable, Toast, and more" }
+          span(class: "hidden sm:inline") { "Native Dialog, Form docs, and more" }
           svg(xmlns: "http://www.w3.org/2000/svg", width: "24", height: "24", viewbox: "0 0 24 24", fill: "none", stroke: "currentColor", stroke_width: "2", stroke_linecap: "round", stroke_linejoin: "round", class: "ml-2 h-4 w-4") { |s|
             s.path(d: "M5 12h14")
             s.path(d: "m12 5 7 7-7 7")

--- a/gem/Gemfile.lock
+++ b/gem/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ruby_ui (1.3.0)
+    ruby_ui (1.4.0)
 
 GEM
   remote: https://rubygems.org/

--- a/gem/lib/ruby_ui.rb
+++ b/gem/lib/ruby_ui.rb
@@ -3,5 +3,5 @@
 require "date"
 
 module RubyUI
-  VERSION = "1.3.0"
+  VERSION = "1.4.0"
 end

--- a/mcp/data/registry.json
+++ b/mcp/data/registry.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.3.0",
+  "version": "1.4.0",
   "components": {
     "accordion": {
       "name": "Accordion",


### PR DESCRIPTION
## Release v1.4.0

Bumps `RubyUI::VERSION` to **1.4.0** and reflects the new version across the gem, docs site, and MCP registry. The gem **has already been published to RubyGems** (`ruby_ui 1.4.0`); this PR lands the version metadata + website changes, after which `v1.4.0` will be tagged + a GitHub release cut.

### Changes
- `gem/lib/ruby_ui.rb` — `VERSION` 1.3.0 → 1.4.0
- `gem/Gemfile.lock`, `docs/Gemfile.lock` — regenerated to `ruby_ui (1.4.0)`
- `docs/app/views/pages/home.rb` — home hero badge → "Native Dialog, Form docs, and more" (the header version badge reads `RubyUI::VERSION` and updates automatically)
- `mcp/data/registry.json` — rebuilt for 1.4.0 (`rake mcp:build`)

### Highlights since v1.3.0
- **Native `<dialog>` element** for Dialog (#435 / #343)
- **Accordion**: closed content now properly hidden instead of trapped at `height: 0` (#433 / #168)
- **Form**: Rails `form_with` integration + real-world docs (#434 / #134)
- Multi-component generator and `as:`-render options (earlier unreleased features)

### How to reproduce / verify
```bash
# Gem
cd gem
grep VERSION lib/ruby_ui.rb          # => "1.4.0"
bundle exec rake                     # tests + standardrb, all green

# MCP registry
head -2 ../mcp/data/registry.json    # "version": "1.4.0"

# Docs site
cd ../docs
bin/dev
# open http://localhost:3000 — hero badge reads "Native Dialog, Form docs, and more";
# header version badge reads 1.4.0
```

### Testing instructions for reviewers
1. Confirm `RubyUI::VERSION == "1.4.0"` and both `Gemfile.lock`s show `ruby_ui (1.4.0)`.
2. Run `cd gem && bundle exec rake` — full suite + StandardRB must pass.
3. Boot the docs site and confirm the home hero badge and header version badge reflect 1.4.0.
4. Confirm `mcp/data/registry.json` top-level `version` is `1.4.0`.

After merge: tag `v1.4.0` on the merge commit and publish the GitHub release.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps the project to v1.4.0 by updating version metadata across the gem, docs site, and MCP registry. Also updates the docs home hero copy and regenerates both lockfiles.

- **New Features**
  - Dialog now uses the native `<dialog>` element.
  - Form: Rails `form_with` integration and practical docs.
  - Multi-component generator and `as:` render options.

- **Bug Fixes**
  - Accordion: closed content is now properly hidden.

<sup>Written for commit 78af352a9755288d4846c0382f7dd329bdca9de6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruby-ui/ruby_ui/pull/436?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

