### PR TITLE
[Documentation] Document the release process in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ Decide the bump with SemVer against commits since the last `vX.Y.Z` tag: new bac
 
 1. **Bump the version (gem).** Edit `RubyUI::VERSION` in `gem/lib/ruby_ui.rb`. Then from each app dir regenerate lockfiles so the path dependency tracks the new version: `gem/Gemfile.lock` and `docs/Gemfile.lock` should both read `ruby_ui (X.Y.Z)`.
 
-2. **Publish the gem to RubyGems.** From `gem/`: `gem build ruby_ui.gemspec` then `gem push ruby_ui-X.Y.Z.gem`. The account has **MFA**, so `gem push` prompts for a one-time password — have the OTP ready (or pass `--otp <CODE>`). Confirm `djalmaaraujo` is in `gem owner ruby_ui` first. Do not commit the built `.gem` artifact.
+2. **Publish the gem to RubyGems.** From `gem/`: `gem build ruby_ui.gemspec` then `gem push ruby_ui-X.Y.Z.gem`. The account has **MFA**, so `gem push` prompts for a one-time password — have the OTP ready (or pass `--otp <CODE>`). Confirm the publishing account is listed in `gem owner ruby_ui` first. Do not commit the built `.gem` artifact.
 
 3. **Reflect the version on the docs website (PR against `main`).** Releases go through a `[Release] vX.Y.Z` PR (main is protected — no direct pushes). The PR bundles, on a `release/vX.Y.Z` branch:
    - the `gem/lib/ruby_ui.rb` bump + both regenerated `Gemfile.lock`s;

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,18 +68,18 @@ Decide the bump with SemVer against commits since the last `vX.Y.Z` tag: new bac
 5. **Hand over the announcement URL (final step).** As the last step, give the user a ready-to-post X.com (Twitter) share link for the RubyUI account — the user posts it manually. Use the prefilled-tweet intent URL with the body URL-encoded:
 
    ```
-   https://x.com/intent/post?text=RubyUI%20X.Y%20released%21%20%F0%9F%9A%80%0A%0Ahttps%3A%2F%2Fwww.rubyui.com%2Fdocs%2Fchangelog
+   https://x.com/intent/post?text=RubyUI%20X.Y.Z%20released%21%20%F0%9F%9A%80%0A%0Ahttps%3A%2F%2Fwww.rubyui.com%2Fdocs%2Fchangelog
    ```
 
    which decodes to:
 
    ```
-   RubyUI X.Y released! 🚀
+   RubyUI X.Y.Z released! 🚀
 
    https://www.rubyui.com/docs/changelog
    ```
 
-   Substitute the real `X.Y` (e.g. `1.4`) in the encoded `text`. Output the link so the user can open and post it.
+   Substitute the real full `X.Y.Z` (e.g. `1.4.0`) in the encoded `text` — always include all three numbers so patch releases get announced too. Output the link so the user can open and post it.
 
 ## Commits & PRs
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,23 @@ bundle exec standardrb
 - Stimulus controllers colocated with components: `<component>_controller.js`. JS deps declared in `gem/package.json` and per-component in `dependencies.yml`.
 - Tests extend `ComponentTest`; render via `phlex { ... }` helper.
 
+## Releasing
+
+A release is **not done** until all four steps below are complete. Skipping the publish, the docs/website reflection, or the git tag leaves the release half-finished.
+
+Decide the bump with SemVer against commits since the last `vX.Y.Z` tag: new backward-compatible features → **minor**; bug fixes / docs only → **patch**. List the range with `git log --oneline vX.Y.Z..HEAD`.
+
+1. **Bump the version (gem).** Edit `RubyUI::VERSION` in `gem/lib/ruby_ui.rb`. Then from each app dir regenerate lockfiles so the path dependency tracks the new version: `gem/Gemfile.lock` and `docs/Gemfile.lock` should both read `ruby_ui (X.Y.Z)`.
+
+2. **Publish the gem to RubyGems.** From `gem/`: `gem build ruby_ui.gemspec` then `gem push ruby_ui-X.Y.Z.gem`. The account has **MFA**, so `gem push` prompts for a one-time password — have the OTP ready (or pass `--otp <CODE>`). Confirm `djalmaaraujo` is in `gem owner ruby_ui` first. Do not commit the built `.gem` artifact.
+
+3. **Reflect the version on the docs website (PR against `main`).** Releases go through a `[Release] vX.Y.Z` PR (main is protected — no direct pushes). The PR bundles, on a `release/vX.Y.Z` branch:
+   - the `gem/lib/ruby_ui.rb` bump + both regenerated `Gemfile.lock`s;
+   - `docs/app/views/pages/home.rb` — update the home hero badge copy to the headline features (the header version badge reads `RubyUI::VERSION` and updates automatically; do not hardcode it);
+   - `mcp/data/registry.json` — rebuild with `cd mcp && bundle exec rake mcp:build` (reads `../gem`, so it picks up the new version).
+
+4. **Tag + GitHub release.** After the release PR merges, tag `vX.Y.Z` on the merge commit, push the tag, and cut the GitHub release. The git tag and the published gem must both exist — publishing the gem without tagging (or vice versa) is an incomplete release.
+
 ## Commits & PRs
 
 - Bracketed prefixes (`[Feature]`, `[Bug Fix]`, `[Documentation]`) or scoped conventional (`feat(scope): ...`).
@@ -58,5 +75,6 @@ bundle exec standardrb
 
 - Don't run commands from repo root expecting them to work — `cd gem` or `cd docs` first.
 - Don't edit a component without updating its `docs/app/views/docs/<component>.rb` counterpart.
-- Don't bump the gem version or release from `docs/`; releases happen in `gem/`.
+- Don't bump the gem version from `docs/`; `RubyUI::VERSION` lives in `gem/lib/ruby_ui.rb` and the gem is published from `gem/`. (The release PR also reflects the version into `docs/` and `mcp/` — see [Releasing](#releasing).)
+- Don't call a release done after only publishing the gem — tag `vX.Y.Z` and reflect the version on the website too.
 - Don't commit secrets; each app uses local env config.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,22 @@ Decide the bump with SemVer against commits since the last `vX.Y.Z` tag: new bac
 
 4. **Tag + GitHub release.** After the release PR merges, tag `vX.Y.Z` on the merge commit, push the tag, and cut the GitHub release. The git tag and the published gem must both exist — publishing the gem without tagging (or vice versa) is an incomplete release.
 
+5. **Hand over the announcement URL (final step).** As the last step, give the user a ready-to-post X.com (Twitter) share link for the RubyUI account — the user posts it manually. Use the prefilled-tweet intent URL with the body URL-encoded:
+
+   ```
+   https://x.com/intent/post?text=RubyUI%20X.Y%20released%21%20%F0%9F%9A%80%0A%0Ahttps%3A%2F%2Fwww.rubyui.com%2Fdocs%2Fchangelog
+   ```
+
+   which decodes to:
+
+   ```
+   RubyUI X.Y released! 🚀
+
+   https://www.rubyui.com/docs/changelog
+   ```
+
+   Substitute the real `X.Y` (e.g. `1.4`) in the encoded `text`. Output the link so the user can open and post it.
+
 ## Commits & PRs
 
 - Bracketed prefixes (`[Feature]`, `[Bug Fix]`, `[Documentation]`) or scoped conventional (`feat(scope): ...`).


### PR DESCRIPTION
## What

Adds a **Releasing** section to the root `CLAUDE.md` so a release is never left half-finished (e.g. gem published but no git tag, or version not reflected on the website).

### Why
A recent release surfaced the gap: the gem was published to RubyGems before the git tag and the docs/website version reflection were done. The steps were tribal knowledge — now they're written down.

### The documented checklist (all four required)
1. **Bump version** in `gem/lib/ruby_ui.rb` + regenerate `gem/Gemfile.lock` and `docs/Gemfile.lock`.
2. **Publish gem** — `gem build` + `gem push` (account has **MFA** → OTP needed; verify `gem owner`).
3. **Reflect on the website** via a `[Release] vX.Y.Z` PR against protected `main` (home hero badge, both lockfiles, `mcp/data/registry.json` rebuilt with `rake mcp:build`).
4. **Tag + GitHub release** on the merge commit.

Also clarifies the now-stale "Don't" line about version bumps so it doesn't contradict the release flow.

### Testing instructions
- Read the rendered `CLAUDE.md` "Releasing" section; confirm the four steps and the SemVer guidance are accurate and the `#releasing` anchor link in Don'ts resolves.
- Docs-only change — no code, no tests affected.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a “Releasing” section to `CLAUDE.md` with a 5-step checklist to finish releases: bump `RubyUI::VERSION` and both lockfiles, publish the gem (MFA; verify `gem owner`), reflect the version on the website via a `[Release] vX.Y.Z` PR, tag and create the GitHub release, and share a prefilled X.com post link that uses the full `X.Y.Z`.
Updates the Don’ts to align with this flow, link to the new section, and remove the hardcoded username from the gem owner check.

<sup>Written for commit eef3e8fe7c9faba5f2c6e0c95ce1b236f7ff2a99. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruby-ui/ruby_ui/pull/437?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

