### PR TITLE
[Bug Fix] Allow non-localhost hosts in docs development env

### DIFF
--- a/docs/config/environments/development.rb
+++ b/docs/config/environments/development.rb
@@ -15,6 +15,9 @@ Rails.application.configure do
   # Enable server timing.
   config.server_timing = true
 
+  # Allow requests from any host in development (VM hostnames, tunnels, Tailscale, etc).
+  config.hosts.clear
+
   # Enable/disable Action Controller caching. By default Action Controller caching is disabled.
   # Run rails dev:cache to toggle Action Controller caching.
   if Rails.root.join("tmp/caching-dev.txt").exist?


### PR DESCRIPTION
## Summary
- Rails 8's Host Authorization middleware only allows `localhost`/private IPs by default, so opening the docs dev server through a VM hostname or Tailscale domain gets rejected with "Blocked hosts".
- Clears `config.hosts` in `docs/config/environments/development.rb` — development-only, does not affect production.

## Test plan
- [x] Ran `bin/rails server -b 0.0.0.0 -p 3000` inside the docs devcontainer
- [x] Confirmed a request with `Host: devmachine.cloud:3001` returns 200 (previously blocked)
- [x] Confirmed `localhost` still works as before

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix docs dev server host blocking by clearing `config.hosts` in development. This allows access via VM hostnames, tunnels, or Tailscale domains (not just localhost) and has no production impact.

<sup>Written for commit a91e550eccfc3a9dcbada7553e439890603697dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruby-ui/ruby_ui/pull/455?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

