### PR TITLE
[Release] v1.5.0

### DIFF
--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -15,7 +15,7 @@ GIT
 PATH
   remote: ../gem
   specs:
-    ruby_ui (1.4.0)
+    ruby_ui (1.5.0)
 
 PATH
   remote: ../mcp

--- a/docs/app/views/pages/home.rb
+++ b/docs/app/views/pages/home.rb
@@ -7,7 +7,7 @@ class Views::Pages::Home < Views::Base
       div(class: "container flex max-w-[64rem] flex-col items-center gap-4 text-center mx-auto") do
         Link(href: docs_changelog_path, variant: :outline, class: "rounded-2xl px-4 py-1.5 text-sm font-medium") do
           span(class: "sm:hidden") { "New components available" }
-          span(class: "hidden sm:inline") { "Native Dialog, Form docs, and more" }
+          span(class: "hidden sm:inline") { "New Bubble, Message, Empty components, and more" }
           svg(xmlns: "http://www.w3.org/2000/svg", width: "24", height: "24", viewbox: "0 0 24 24", fill: "none", stroke: "currentColor", stroke_width: "2", stroke_linecap: "round", stroke_linejoin: "round", class: "ml-2 h-4 w-4") { |s|
             s.path(d: "M5 12h14")
             s.path(d: "m12 5 7 7-7 7")

--- a/gem/Gemfile.lock
+++ b/gem/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ruby_ui (1.4.0)
+    ruby_ui (1.5.0)
 
 GEM
   remote: https://rubygems.org/

--- a/gem/lib/ruby_ui.rb
+++ b/gem/lib/ruby_ui.rb
@@ -3,5 +3,5 @@
 require "date"
 
 module RubyUI
-  VERSION = "1.4.0"
+  VERSION = "1.5.0"
 end

--- a/mcp/data/registry.json
+++ b/mcp/data/registry.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.4.0",
+  "version": "1.5.0",
   "components": {
     "accordion": {
       "name": "Accordion",


### PR DESCRIPTION
Release PR for **v1.5.0** (minor — new components accumulated since v1.4.0).

## Changes in this PR
- `gem/lib/ruby_ui.rb`: `VERSION` → `1.5.0`
- `gem/Gemfile.lock` + `docs/Gemfile.lock`: regenerated (`ruby_ui (1.5.0)`)
- `docs/app/views/pages/home.rb`: hero badge copy → headline features (the header version badge reads `RubyUI::VERSION` and updates automatically)
- `mcp/data/registry.json`: rebuilt via `rake mcp:build`

## Highlights since v1.4.0
**New components (minor):**
- Bubble (#445), Message (#446), Message Scroller (#447), Empty (#448)
- Port hover_card & context_menu to Floating UI, drop Popper.js (#438)

**Bug fixes:**
- Dialog: closed native `<dialog>` stayed visible + stale docs controller (#458)
- DropdownMenu: z-index stacking & default placement (#440)
- Allow non-localhost hosts in docs dev env (#455)

## Post-merge release steps
- [ ] `gem build` + `gem push` to RubyGems (MFA/OTP — done by maintainer)
- [ ] Tag `v1.5.0` on the merge commit + push
- [ ] Cut the GitHub release (its body populates the docs changelog)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release v1.5.0 of `ruby_ui`, bumping the version, refreshing lockfiles, updating the docs home hero to highlight new components, and rebuilding the MCP registry. This minor release adds new components and fixes Dialog and DropdownMenu issues.

- **New Features**
  - Added Bubble, Message, Message Scroller, and Empty components.
  - Ported `hover_card` and `context_menu` to `Floating UI` (removed `Popper.js`).

- **Bug Fixes**
  - Dialog: fixed visibility after close and stale docs controller.
  - DropdownMenu: fixed z-index stacking and default placement.

<sup>Written for commit e642c19ae5492d41a2dd5dd23ee11ff89b95d915. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruby-ui/ruby_ui/pull/459?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

