### PR TITLE
[Documentation] Add ruby-ui-stimulus agent skill

### DIFF
--- a/.claude/skills/ruby-ui-stimulus/NOTICE.md
+++ b/.claude/skills/ruby-ui-stimulus/NOTICE.md
@@ -1,0 +1,37 @@
+# Attribution
+
+The controller-quality patterns and guardrails in this skill (`SKILL.md` and
+`references/stimulus-fundamentals.md`) are adapted from **The Hotwire Club
+skills** — specifically the `hwc-stimulus-fundamentals` skill — available at
+https://github.com/TheHotwireClub/hotwire_club-skills and used under the MIT
+License.
+
+The ruby_ui-specific conventions in `references/phlex-stimulus-conventions.md`
+(Phlex `default_attrs` wiring, the `ruby-ui--` naming scheme, manifest
+registration, `dependencies.yml`) are original to this repository.
+
+## Original license (The Hotwire Club skills)
+
+```
+MIT License
+
+Copyright (c) 2026 The Hotwire Club
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```

--- a/.claude/skills/ruby-ui-stimulus/SKILL.md
+++ b/.claude/skills/ruby-ui-stimulus/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: ruby-ui-stimulus
+description: >-
+  Use when writing, reviewing, or debugging a Stimulus controller for a ruby_ui
+  Phlex component — controller lifecycle, state via values, DOM via targets,
+  inter-controller communication via outlets, and the ruby_ui-specific
+  data-attribute / naming / registration conventions. Covers how a Phlex
+  component wires Stimulus through `data:` in `default_attrs`. Adapted from
+  The Hotwire Club skills (MIT); see NOTICE.md.
+---
+
+# RubyUI Stimulus conventions
+
+RubyUI adds interactivity with Stimulus controllers colocated with each Phlex
+component: `gem/lib/ruby_ui/<component>/<component>_controller.js`. The component
+class wires the controller through the `data:` hash returned by `default_attrs`.
+There is **no custom helper/DSL** — everything is plain Phlex attributes plus
+Stimulus conventions.
+
+This skill covers **client-side interactivity via Stimulus**, which is the norm
+for RubyUI components. Turbo (Frames/Streams) is out of scope here — it is only
+used server-driven, and today the sole case is `DataTable`.
+
+## Core workflow
+
+Building or changing a Stimulus-backed component:
+
+1. **Write the controller** at `gem/lib/ruby_ui/<component>/<component>_controller.js`,
+   extending `Controller` from `@hotwired/stimulus`. Keep a clean lifecycle
+   (`connect`/`disconnect`) — see the guardrails below.
+2. **Model the contract with statics, not ad-hoc DOM reads:**
+   - `static values` for reactive state (`openValue`, `optionsValue`, …).
+   - `static targets` for the DOM nodes the controller touches.
+   - `static outlets` for talking to sibling/child controllers.
+   Prefer these over reading `this.element.dataset` or querying the DOM by hand.
+3. **Wire from the Phlex component** in `default_attrs`: set
+   `data: { controller: "ruby-ui--<component>", … }`, plus targets, actions, and
+   values using the underscore keys Phlex converts to `data-*` attributes. Exact
+   naming table and worked examples: `references/phlex-stimulus-conventions.md`.
+4. **Register & declare deps:**
+   - Importmap apps eager-load `controllers/` — no manifest edit needed.
+   - esbuild/webpack apps regenerate the manifest with
+     `rake stimulus:manifest:update` (`docs/app/javascript/controllers/index.js`).
+   - New JS packages go in `gem/package.json` **and** per-component in
+     `gem/lib/generators/ruby_ui/dependencies.yml`.
+5. **Update docs & tests** in the same PR: `<component>_docs.rb` and
+   `test/ruby_ui/<component>_test.rb` (see `gem/AGENTS.md`).
+
+## Guardrails
+
+- **Symmetric setup/teardown.** Every listener, timer, `MutationObserver`, or
+  Floating UI `autoUpdate` added in `connect()` must be removed/cleaned in
+  `disconnect()`. `popover_controller.js` is the canonical example
+  (`addEventListeners`/`removeEventListeners` + `this.cleanup()`).
+- **Idempotent `connect()`.** Controllers reconnect on Turbo navigation and DOM
+  changes; connecting twice must not double-bind or leak.
+- **Declarative over imperative.** Reach for `static values` + action parameters
+  before parsing `dataset` or hand-wiring `addEventListener`. Use `<name>Changed`
+  value callbacks to react to state instead of scattering conditionals.
+- **Feature-detect** browser APIs (Clipboard, Web Share, View Transitions, …)
+  before exposing UI that depends on them.
+- **No fixed timeouts as a proxy for completion.** Drive UI off real signals
+  (value-changed callbacks, native/Turbo events), not a guessed `setTimeout`.
+- **Always namespace `ruby-ui--`.** Controller identifiers, target/value/outlet
+  keys all carry the `ruby-ui--<component>` prefix. Never register a bare
+  identifier — it would collide with a consumer app's own controllers.
+- **Don't invent a Ruby DSL** for data attributes. Follow the existing
+  `data:` / `default_attrs` pattern documented in the references.
+
+## Load references selectively
+
+- `references/phlex-stimulus-conventions.md` — the ruby_ui-specific mechanics:
+  naming table (folder → identifier → HTML attribute), how `default_attrs`
+  wires `data:` (both nested-hash and flattened-key styles), outlets, manifest
+  registration, and `dependencies.yml`. Read this to wire the Phlex side.
+- `references/stimulus-fundamentals.md` — controller-quality patterns (lifecycle,
+  values, targets, outlets, action parameters, guardrail rationale) adapted to
+  Phlex/ruby_ui. Read this to write a well-behaved controller.
+
+## Attribution
+
+Controller-quality patterns and guardrails are adapted from
+[The Hotwire Club skills](https://github.com/TheHotwireClub/hotwire_club-skills)
+(`hwc-stimulus-fundamentals`), used under the MIT License. Full notice in
+`NOTICE.md`.

--- a/.claude/skills/ruby-ui-stimulus/references/phlex-stimulus-conventions.md
+++ b/.claude/skills/ruby-ui-stimulus/references/phlex-stimulus-conventions.md
@@ -1,0 +1,161 @@
+# Phlex ↔ Stimulus wiring conventions (ruby_ui)
+
+How RubyUI components connect their Phlex markup to Stimulus controllers. All
+examples are real code from `gem/lib/ruby_ui/`.
+
+## Naming table
+
+A component lives in a snake_case folder; its Stimulus identifier is the folder
+path with `/` → `--` (so the `ruby_ui/` namespace becomes the `ruby-ui--`
+prefix). Phlex converts each `_` in an attribute key to `-`, so `__` becomes
+`--` in the emitted HTML.
+
+| Thing | Folder / Ruby | Stimulus identifier | HTML attribute emitted |
+| --- | --- | --- | --- |
+| Controller | `popover/` → `popover_controller.js` | `ruby-ui--popover` | `data-controller="ruby-ui--popover"` |
+| Target `trigger` | `ruby_ui__popover_target: "trigger"` | — | `data-ruby-ui--popover-target="trigger"` |
+| Value `open` | `ruby_ui__popover_open_value: "false"` | `openValue` | `data-ruby-ui--popover-open-value="false"` |
+| Action | `action: "click->ruby-ui--popover#toggle"` | — | `data-action="click->ruby-ui--popover#toggle"` |
+| Outlet | `ruby_ui__select_ruby_ui__select_item_outlet: ".item"` | — | `data-ruby-ui--select-ruby-ui--select-item-outlet=".item"` |
+
+The controller file itself is anonymous (`export default class extends
+Controller`); the identifier comes from **where it is registered**, not from the
+file. See "Registration" below.
+
+## Two ways to write `data:` in `default_attrs`
+
+Both are valid Phlex and both appear in the codebase. Pick one per component and
+be consistent.
+
+**Nested hash** (most common — `popover.rb`, `clipboard.rb`, `select.rb`):
+
+```ruby
+# gem/lib/ruby_ui/clipboard/clipboard.rb
+def default_attrs
+  {
+    data: {
+      controller: "ruby-ui--clipboard",
+      action: "click@window->ruby-ui--clipboard#onClickOutside",
+      ruby_ui__clipboard_success_value: @success,
+      ruby_ui__clipboard_error_value: @error,
+      ruby_ui__clipboard_options_value: @options.to_json
+    }
+  }
+end
+```
+
+**Flattened keys** (`dialog_content.rb`) — the whole `data-...` name is one key:
+
+```ruby
+# gem/lib/ruby_ui/dialog/dialog_content.rb
+def default_attrs
+  {
+    data_ruby_ui__dialog_target: "dialog",
+    data_action: "click->ruby-ui--dialog#backdropClick",
+    class: [...]
+  }
+end
+```
+
+`default_attrs` is merged with the caller's attributes by `Base#initialize`
+(`gem/lib/ruby_ui/base.rb`) via Phlex `mix`, with Tailwind classes deduped by
+`TailwindMerge`. So callers can add/override `data-*` and classes without
+clobbering the component's wiring.
+
+## Values
+
+Pass values as strings/JSON from Ruby; declare their type in the controller:
+
+```ruby
+# popover.rb
+ruby_ui__popover_options_value: @options.to_json      # Object value → JSON string
+ruby_ui__popover_trigger_value: @options[:trigger] || "hover"
+```
+
+```js
+// popover_controller.js
+static values = {
+  open: { type: Boolean, default: false },
+  options: { type: Object, default: {} },   // parsed from the JSON string
+  trigger: { type: String, default: "hover" },
+};
+```
+
+React to changes with the auto-called `<name>Changed(newVal, oldVal)` callback
+rather than polling.
+
+## Targets
+
+Child/sub-components mark themselves as targets of the parent controller:
+
+```ruby
+# select_item.rb — an item is a target of the ruby-ui--select controller
+data: {
+  controller: "ruby-ui--select-item",
+  action: "click->ruby-ui--select#selectItem keydown.enter->ruby-ui--select#selectItem ...",
+  ruby_ui__select_target: "item"
+}
+```
+
+Multiple actions go in a single space-separated string, as above.
+
+## Actions on non-element scopes
+
+Use `@window` / `@document` scope for outside-click and global handlers:
+
+```ruby
+# clipboard.rb
+action: "click@window->ruby-ui--clipboard#onClickOutside"
+# select.rb
+action: "click@window->ruby-ui--select#clickOutside"
+```
+
+A trigger sub-component can dispatch to an ancestor controller without declaring
+its own `controller:` — it relies on the parent controller being on an ancestor
+element:
+
+```ruby
+# dialog_trigger.rb
+data: { action: "click->ruby-ui--dialog#open" }
+```
+
+## Outlets (parent ↔ child controllers)
+
+The parent declares the outlet selector; the child is a separate controller the
+parent can call into:
+
+```ruby
+# select.rb — parent declares the outlet to select-item
+data: {
+  controller: "ruby-ui--select",
+  ruby_ui__select_ruby_ui__select_item_outlet: ".item"
+}
+```
+
+Outlet attribute shape: `data-<controller>-<outlet-identifier>-outlet`, hence the
+doubled `ruby_ui__…_ruby_ui__…_outlet` key in Ruby.
+
+## Registration
+
+- **Importmap** apps (Rails default): controllers are eager-loaded from
+  `controllers/` — nothing to register manually.
+- **esbuild/webpack** apps: the manifest `docs/app/javascript/controllers/index.js`
+  is auto-generated; regenerate with `rake stimulus:manifest:update`. Each entry is:
+
+  ```js
+  import RubyUi__PopoverController from "./ruby_ui/popover_controller"
+  application.register("ruby-ui--popover", RubyUi__PopoverController)
+  ```
+
+  Note the file path segment `ruby_ui/` + `popover_controller` maps to identifier
+  `ruby-ui--popover`.
+
+## Dependencies
+
+Declare any JS package the controller imports (e.g. `@floating-ui/dom`,
+`fuse.js`, `embla-carousel`) in two places:
+
+- `gem/package.json` — for the gem's own dev/test.
+- `gem/lib/generators/ruby_ui/dependencies.yml` — per-component map so the
+  generator installs it into consumer apps (also lists required gems and other
+  components a component depends on).

--- a/.claude/skills/ruby-ui-stimulus/references/stimulus-fundamentals.md
+++ b/.claude/skills/ruby-ui-stimulus/references/stimulus-fundamentals.md
@@ -1,0 +1,116 @@
+# Stimulus controller fundamentals (ruby_ui flavour)
+
+Controller-quality patterns adapted from The Hotwire Club's
+`hwc-stimulus-fundamentals` (MIT — see `NOTICE.md`), with ruby_ui examples.
+Use this when writing the JS controller; use `phlex-stimulus-conventions.md` for
+the Ruby/Phlex side.
+
+## The controller as a contract
+
+A controller's public surface is its statics. Declare them; don't reach around
+them.
+
+- `static targets = [...]` — DOM nodes the controller reads/writes. Access via
+  `this.<name>Target` / `this.<name>Targets`, guard with `this.has<Name>Target`.
+- `static values = {...}` — reactive state, typed and defaulted. Reading/writing
+  `this.<name>Value` syncs to the `data-*-value` attribute. A `<name>Changed`
+  method is called automatically on change (and once on connect).
+- `static outlets = [...]` — other controllers this one collaborates with.
+- `static classes = [...]` — CSS class names supplied via `data-*-class`, instead
+  of hardcoding class strings in JS.
+
+```js
+// popover_controller.js
+export default class extends Controller {
+  static targets = ["trigger", "content"];
+  static values = {
+    open: { type: Boolean, default: false },
+    options: { type: Object, default: {} },
+    trigger: { type: String, default: "hover" },
+  };
+}
+```
+
+## Lifecycle: symmetric setup and teardown
+
+This is the rule that breaks most often under Turbo navigation. Whatever
+`connect()` allocates, `disconnect()` must release. `popover_controller.js` is
+the canonical example:
+
+```js
+connect() {
+  this.closeTimeout = null;
+  this.cleanup = null;          // Floating UI autoUpdate handle
+  this.addEventListeners();
+}
+
+disconnect() {
+  this.removeEventListeners();  // every listener added in connect()
+  if (this.cleanup) this.cleanup();   // stop autoUpdate
+}
+```
+
+Checklist for `disconnect()`:
+- Remove every `addEventListener` (including `document`/`window` ones).
+- `clearTimeout`/`clearInterval` any pending timers.
+- Disconnect any `MutationObserver`/`ResizeObserver`/`IntersectionObserver`.
+- Call cleanup handles from libraries (Floating UI `autoUpdate`, Embla, charts).
+
+Bind handlers as class fields (`handleClick = (e) => {...}`) so the same
+reference can be added and removed — see popover's `handleMouseEnter` etc.
+
+## Idempotency
+
+Controllers can connect more than once (Turbo restores, DOM re-inserts). `connect()`
+must be safe to run repeatedly: null-out state up front, and never assume a fresh
+element.
+
+## React to state via value callbacks
+
+Prefer `<name>Changed` over branching everywhere the state is used:
+
+```js
+openValueChanged(isOpen) {
+  isOpen ? this.showPopover() : this.hidePopover();
+}
+```
+
+Set `this.openValue = true` and let the callback drive the DOM.
+
+## Prefer declarative wiring
+
+- Pass data through **action parameters** and **values**, not by parsing
+  `this.element.dataset` by hand.
+- Multiple actions belong in one space-separated `data-action` string
+  (see `select_item.rb`), including keyboard actions like
+  `keydown.enter->…#selectItem keydown.esc->…#handleEsc`.
+- Use `@window`/`@document` action scopes for outside-click and global keys
+  instead of manually attaching to `document` where you can.
+
+## Cross-controller communication via outlets
+
+When a parent controller must coordinate children (e.g. `ruby-ui--select`
+managing `ruby-ui--select-item`s), declare an outlet rather than querying the DOM
+or dispatching brittle custom events. The parent gets typed access to each outlet
+controller instance. Wiring shown in `phlex-stimulus-conventions.md` → Outlets.
+
+## Feature detection
+
+Guard optional browser APIs before exposing UI that needs them
+(Clipboard, Web Share, View Transitions). Fall back gracefully; never assume
+support.
+
+## Avoid timing hacks
+
+Don't use a fixed `setTimeout` as a stand-in for "the thing finished". Drive UI
+off real signals: value-changed callbacks, `transitionend`, native events, or
+(for server-driven flows) Turbo events like `turbo:submit-end`. The one legitimate
+timer in popover is a short *debounce* on mouse-leave — and it is cleared on the
+next mouse-enter and on disconnect, not used to detect completion.
+
+## Escalation
+
+If a component genuinely needs server-driven updates (partial re-render, live
+push), that is Turbo Frames/Streams territory — out of scope for this skill.
+Today the only server-driven case in the gem is `DataTable` (Turbo Frame). Most
+components should stay client-side Stimulus.

--- a/gem/AGENTS.md
+++ b/gem/AGENTS.md
@@ -81,6 +81,8 @@ Rails generators in `lib/generators/ruby_ui/` handle installation into consumer 
 
 Stimulus controllers live alongside their Ruby components. JS dependencies (Chart.js, Embla, Floating UI, etc.) are declared in `package.json` and mapped per-component in `dependencies.yml`.
 
+When writing or reviewing a Stimulus controller, follow the **`ruby-ui-stimulus`** skill (`.claude/skills/ruby-ui-stimulus/` at the monorepo root) — it covers controller lifecycle/guardrails and the ruby_ui wiring conventions. Quick rules: identifier is `ruby-ui--<component>`; wire it from the Phlex component via `data:` in `default_attrs` (no custom helper); keep `connect`/`disconnect` symmetric; register in the manifest with `rake stimulus:manifest:update` (esbuild/webpack; importmap eager-loads); declare new JS packages in both `package.json` and `dependencies.yml`.
+
 ## CI
 
 GitHub Actions (`.github/workflows/ci.yml`) runs `rake test` and `rake standard` against Ruby 3.3 and 3.4 on every push to main and on PRs.


### PR DESCRIPTION
## What

Adds an on-demand **agent skill** (`ruby-ui-stimulus`) that codifies how RubyUI wires Stimulus controllers to Phlex components, plus a short pointer in `gem/AGENTS.md`.

Inspired by [The Hotwire Club skills](https://github.com/TheHotwireClub/hotwire_club-skills) (MIT). Since RubyUI uses Phlex (not ERB) and is a component gem (not an app), only the template-agnostic core — `hwc-stimulus-fundamentals` — is relevant; it's been adapted to Phlex and paired with RubyUI's own naming/wiring conventions.

## Why

There was no documented Stimulus/Hotwire convention in `gem/AGENTS.md` or as a skill — the pattern only existed "by example", leaving new controllers inconsistent. A skill loads on demand (only when writing/reviewing a controller), so it doesn't tax every session's context the way inlining it in the always-loaded docs would.

## Contents

- `.claude/skills/ruby-ui-stimulus/SKILL.md` — core workflow + guardrails (lifecycle symmetry, idempotent `connect`, declarative values/targets/outlets, `ruby-ui--` namespacing)
- `references/phlex-stimulus-conventions.md` — naming table, `data:`/`default_attrs` wiring (both nested-hash and flattened-key styles), outlets, manifest registration, `dependencies.yml`
- `references/stimulus-fundamentals.md` — controller-quality patterns adapted from `hwc-stimulus-fundamentals`
- `NOTICE.md` — MIT attribution to The Hotwire Club
- `gem/AGENTS.md` — pointer to the skill from the JavaScript section

All examples are drawn from real components (`popover`, `clipboard`, `select`, `dialog`).

## Scope notes

- Out of scope by design: the other 5 Hotwire Club skills (app-level: forms, navigation, media, streaming, UX) and Turbo Frames/Streams guidance (only `DataTable` uses a Frame today).
- No component/controller code changed — documentation only.

## Testing

- Skill frontmatter is valid (`name` + `description`) and the skill is picked up by Claude Code.
- Docs-only change; no Ruby/JS touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the on-demand `ruby-ui-stimulus` agent skill to codify how RubyUI wires Stimulus controllers to Phlex components, plus a short pointer in `gem/AGENTS.md`. This standardizes controller lifecycle and naming to keep new controllers consistent.

- **New Features**
  - Introduces `ruby-ui-stimulus` skill with core workflow and guardrails (idempotent `connect`, symmetric `disconnect`, declarative `values/targets/outlets`, `ruby-ui--` namespacing, feature detection).
  - Adds references: Phlex ↔ Stimulus wiring (naming table, `default_attrs` nested/flat styles, outlets, `rake stimulus:manifest:update`, dependency mapping) and Stimulus fundamentals adapted for RubyUI; includes MIT attribution in `NOTICE.md`.
  - Updates `gem/AGENTS.md` to link the skill for quick discovery when writing or reviewing controllers.

<sup>Written for commit d45a44fcbc13f950d371aa1c882befa42b7f568a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruby-ui/ruby_ui/pull/478?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

