### PR TITLE
[Bug Fix] Accordion: sync docs Stimulus controller with gem

### DIFF
--- a/docs/app/javascript/controllers/ruby_ui/accordion_controller.js
+++ b/docs/app/javascript/controllers/ruby_ui/accordion_controller.js
@@ -65,9 +65,15 @@ export default class extends Controller {
 
   // Reveal the accordion content with animation
   revealContent() {
-    const contentHeight = this.contentTarget.scrollHeight;
+    const content = this.contentTarget;
+
+    // Remove hidden so the element participates in layout before measuring
+    content.removeAttribute("hidden");
+    content.dataset.state = "open";
+
+    const contentHeight = content.scrollHeight;
     animate(
-      this.contentTarget,
+      content,
       { height: `${contentHeight}px` },
       {
         duration: this.animationDurationValue,
@@ -78,14 +84,23 @@ export default class extends Controller {
 
   // Hide the accordion content with animation
   hideContent() {
+    const content = this.contentTarget;
+    content.dataset.state = "closed";
+
     animate(
-      this.contentTarget,
+      content,
       { height: 0 },
       {
         duration: this.animationDurationValue,
         easing: this.animationEasingValue,
       },
-    );
+    ).finished.then(() => {
+      // After animation completes, truly hide the element so it is removed
+      // from layout and form focus — prevents trapped validation errors
+      if (content.dataset.state === "closed") {
+        content.setAttribute("hidden", "");
+      }
+    });
   }
 
   // Rotate the accordion icon 180deg using animate function


### PR DESCRIPTION
Fixes #489

## Summary
- The gem's accordion controller was fixed in 0897b2a to toggle the `hidden` attribute on the content element in sync with the height animation.
- `docs/app/javascript/controllers/ruby_ui/accordion_controller.js` is a separate copy (docs bundles its own JS controllers) that was never updated after that fix, so the live preview at rubyui.com/docs/accordion never opened when clicked.
- Copied the gem's controller verbatim into the docs copy — confirmed byte-identical with `diff`.

The `Accordion` component in the gem itself was already correct; no gem changes needed.

## Test plan
- [x] Reproduced the bug on production (rubyui.com/docs/accordion): clicking a trigger did nothing.
- [x] `diff gem/lib/ruby_ui/accordion/accordion_controller.js docs/app/javascript/controllers/ruby_ui/accordion_controller.js` → identical.
- [x] Rebuilt docs assets (`pnpm build`) locally in the docs devcontainer, ran the Rails dev server, and manually verified in browser: trigger now opens (content reveals, chevron rotates) and closes (content hides, chevron resets) correctly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sync the docs accordion Stimulus controller with the gem so accordion previews open and close correctly. Fixes #489.

- **Bug Fixes**
  - Replaced the docs controller with the gem version to toggle the `hidden` attribute in sync with the height animation.
  - Removes `hidden` before measuring height and re-applies it after the close animation to avoid layout/focus issues.

<sup>Written for commit c989ae6d98e45c275a062130f4f71c7cf84044af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruby-ui/ruby_ui/pull/490?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

