### PR TITLE
[Bug Fix] MCP: point install instructions at canonical www host

### DIFF
--- a/docs/app/views/docs/mcp.rb
+++ b/docs/app/views/docs/mcp.rb
@@ -25,7 +25,7 @@ class Views::Docs::Mcp < Views::Base
         # Claude Code
         div(class: "space-y-2") do
           Heading(level: 3) { "Claude Code" }
-          Codeblock("claude mcp add --transport http ruby-ui https://rubyui.com/mcp", syntax: :shell, clipboard: true)
+          Codeblock("claude mcp add --transport http ruby-ui https://www.rubyui.com/mcp", syntax: :shell, clipboard: true)
         end
 
         # Cursor
@@ -118,7 +118,7 @@ class Views::Docs::Mcp < Views::Base
     <<~JSON
       {
         "mcpServers": {
-          "ruby-ui": { "url": "https://rubyui.com/mcp" }
+          "ruby-ui": { "url": "https://www.rubyui.com/mcp" }
         }
       }
     JSON
@@ -132,7 +132,7 @@ class Views::Docs::Mcp < Views::Base
     <<~JSON
       {
         "context_servers": {
-          "ruby-ui": { "source": "http", "url": "https://rubyui.com/mcp" }
+          "ruby-ui": { "source": "http", "url": "https://www.rubyui.com/mcp" }
         }
       }
     JSON

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -2,7 +2,7 @@
 
 Model Context Protocol (MCP) server for [Ruby UI](https://rubyui.com). Lets AI coding agents discover, inspect, and install Ruby UI components.
 
-Hosted endpoint: **https://rubyui.com/mcp**
+Hosted endpoint: **https://www.rubyui.com/mcp**
 
 ## Tools
 

--- a/mcp/lib/ruby_ui/mcp/tools/get_project_registries.rb
+++ b/mcp/lib/ruby_ui/mcp/tools/get_project_registries.rb
@@ -10,7 +10,7 @@ module RubyUI
           {
             registries: [{
               name: "ruby_ui",
-              url: "https://rubyui.com/mcp",
+              url: "https://www.rubyui.com/mcp",
               description: "Ruby UI components for Phlex + Rails."
             }]
           }


### PR DESCRIPTION
Related to #481 (second sub-problem, not the Host-header rejection itself — that's PR #491).

## Problem

`https://rubyui.com/mcp` 301-redirects to `https://www.rubyui.com/mcp`. A redirect mid-handshake trips some MCP clients. Every place we hand people (or agents) the endpoint to copy-paste pointed at the bare, redirecting domain:

- `docs/app/views/docs/mcp.rb` — the Claude Code `claude mcp add` snippet, and the Cursor/Claude Desktop/Windsurf/Zed JSON config snippets.
- `mcp/lib/ruby_ui/mcp/tools/get_project_registries.rb` — the `url` the `get_project_registries` MCP tool itself hands back to a connected agent at runtime.
- `mcp/README.md` — the "Hosted endpoint" line.

## Fix

Point all of the above at `https://www.rubyui.com/mcp` directly — the actual final destination — so copying any of these no longer round-trips through a redirect. Left alone the general "visit the site" links (e.g. `mcp/README.md`'s intro link and its "see docs" link, root `CLAUDE.md`/`README.md`), since those are normal browser navigations where a 301 is harmless.

## Test plan

- `cd mcp && bundle exec rake test` — 24 runs, 59 assertions, 0 failures (no test asserts the literal URL string, so nothing needed updating there).
- `bundle exec standardrb` on the changed Ruby files — clean.
- Confirmed `mcp/data/registry.json` (the static build artifact) doesn't embed this URL, so no rebuild needed.
- Grepped the repo for any remaining `rubyui.com/mcp` (bare, non-www) references — none left.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Point MCP install and config instructions to the canonical host to avoid mid-handshake redirects that break some clients. All endpoints now use https://www.rubyui.com/mcp.

- **Bug Fixes**
  - Updated docs snippets (Claude Code, Cursor, Zed) to use https://www.rubyui.com/mcp.
  - Updated `get_project_registries` tool to return https://www.rubyui.com/mcp.
  - Updated `mcp/README.md` hosted endpoint.

<sup>Written for commit 69db642aa45520bf0b842c676c0703a252f5a819. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruby-ui/ruby_ui/pull/492?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

