### PR TITLE
[Release] v1.6.0

### DIFF
--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -15,7 +15,7 @@ GIT
 PATH
   remote: ../gem
   specs:
-    ruby_ui (1.5.0)
+    ruby_ui (1.6.0)
 
 PATH
   remote: ../mcp

--- a/docs/app/views/pages/home.rb
+++ b/docs/app/views/pages/home.rb
@@ -7,7 +7,7 @@ class Views::Pages::Home < Views::Base
       div(class: "container flex max-w-[64rem] flex-col items-center gap-4 text-center mx-auto") do
         Link(href: docs_changelog_path, variant: :outline, class: "rounded-2xl px-4 py-1.5 text-sm font-medium") do
           span(class: "sm:hidden") { "New components available" }
-          span(class: "hidden sm:inline") { "New Bubble, Message, Empty components, and more" }
+          span(class: "hidden sm:inline") { "New InputOtp component, configurable Combobox placement, and more" }
           svg(xmlns: "http://www.w3.org/2000/svg", width: "24", height: "24", viewbox: "0 0 24 24", fill: "none", stroke: "currentColor", stroke_width: "2", stroke_linecap: "round", stroke_linejoin: "round", class: "ml-2 h-4 w-4") { |s|
             s.path(d: "M5 12h14")
             s.path(d: "m12 5 7 7-7 7")

--- a/gem/Gemfile.lock
+++ b/gem/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ruby_ui (1.5.0)
+    ruby_ui (1.6.0)
 
 GEM
   remote: https://rubygems.org/

--- a/gem/lib/ruby_ui.rb
+++ b/gem/lib/ruby_ui.rb
@@ -3,5 +3,5 @@
 require "date"
 
 module RubyUI
-  VERSION = "1.5.0"
+  VERSION = "1.6.0"
 end

--- a/mcp/data/registry.json
+++ b/mcp/data/registry.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.5.0",
+  "version": "1.6.0",
   "components": {
     "accordion": {
       "name": "Accordion",


### PR DESCRIPTION
## Release

Bumps `RubyUI::VERSION` to **1.6.0**. Minor per SemVer — a new component and new component options landed since `v1.5.0`, no breaking changes.

- `gem/lib/ruby_ui.rb` → `1.6.0`
- `gem/Gemfile.lock` + `docs/Gemfile.lock` regenerated (both now read `ruby_ui (1.6.0)`; version line is the only change in each)
- `docs/app/views/pages/home.rb` — hero badge copy updated to the headline features. The header version badge reads `RubyUI::VERSION` and needs no edit.
- `mcp/data/registry.json` — rebuilt with `cd mcp && bundle exec rake mcp:build`

## Highlights since v1.5.0

**New component**
- InputOtp (#456)

**Component improvements**
- Combobox: configurable popover placement + `minPopoverWidth` (#480), CheckboxGroup reuse for required `ComboboxCheckbox` (#479), single chevron-down icon in trigger (#475)
- DataTable: custom label and initial column visibility in `DataTableColumnToggle` (#466)

**Bug fixes**
- Popover: sets `data-state`/`data-side`, clears `closeTimeout` on disconnect, closes on Escape (#495)
- Accordion: releases the panel height to `auto` after opening, so content that grows later is no longer clipped (#500); docs controller synced with gem (#490)
- Toast: toaster state moved to `initialize()` so a server-rendered toast inside `Toaster` no longer throws before `connect()` (#499)
- NativeSelect: `viewBox` capitalization on the chevron icon (#467)

**Infrastructure / docs site**
- Docs Stimulus controllers are symlinks into `gem/lib/ruby_ui/<component>/` instead of hand-maintained copies (#493)
- New RubyUI logo, wordmark and favicon set (#463, #464, #468, #476)
- MCP: canonical `www` host in install instructions (#492), `rubyui.com` allowed through DNS-rebinding protection (#491)

## Verification

- `cd gem && bundle exec rake` — 281 runs, 1251 assertions, 0 failures, 0 errors; standardrb clean across 402 files
- Both `Gemfile.lock` diffs confirmed to be the `ruby_ui` version line only
- `mcp/data/registry.json` rebuilt and reports `"version": "1.6.0"`

## Remaining release steps

1. Publish `ruby_ui-1.6.0.gem` to RubyGems (account has MFA — needs an OTP)
2. Merge this PR
3. Tag `v1.6.0` on the merge commit, push the tag, cut the GitHub release — the release body is what feeds the changelog page, which renders from the GitHub releases feed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release `ruby_ui` 1.6.0 with a new `InputOtp` component and new options for Combobox and DataTable; no breaking changes. Docs hero text and MCP registry updated to 1.6.0.

- New Features
  - `InputOtp` component.
  - Combobox: configurable popover placement and `minPopoverWidth`.
  - DataTable: custom label and initial column visibility in `DataTableColumnToggle`.

- Bug Fixes
  - Popover: sets `data-state`/`data-side`, clears `closeTimeout`, closes on Escape.
  - Accordion: panel height releases to auto to prevent clipping.
  - Toast: initialize toaster state in `initialize()` to avoid server-rendered errors.
  - NativeSelect: fix `viewBox` capitalization.

<sup>Written for commit 86e4bc79470351f80e465e145df04edef593fb65. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruby-ui/ruby_ui/pull/501?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

