### PR TITLE
[Bug Fix] Docs: fix GitHub source URL for monorepo structure

### DIFF
--- a/docs/app/views/base.rb
+++ b/docs/app/views/base.rb
@@ -2,7 +2,7 @@ class Views::Base < Components::Base
   include ApplicationHelper
 
   GITHUB_REPO_URL = "https://github.com/ruby-ui/ruby_ui/"
-  GITHUB_FILE_URL = "#{GITHUB_REPO_URL}blob/main/"
+  GITHUB_FILE_URL = "#{GITHUB_REPO_URL}blob/main/gem/"
 
   def before_template
     Docs::VisualCodeExample.reset_collected_code


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does, explaining the decision(s) you made if necessary. -->

The GITHUB_FILE_URL was missing the `gem/` path prefix, causing 404
errors when clicking source code links. Now correctly points to the
gem directory within the monorepo.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the docs source code link so it no longer returns a 404 when clicking through to the source on GitHub.

- Adds the missing `gem/` path prefix to the generated GitHub file URL so it points to the correct directory in the monorepo.

<sup>Written for commit cd7af79408c73e30df8b9ed3e9fc510f2e40d5e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ruby-ui/ruby_ui/pull/525?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

